### PR TITLE
chore: fix ci token for protected branch

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - name: 🛒 Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 💿 Setup Nodejs
         uses: actions/setup-node@v3
@@ -49,5 +52,5 @@ jobs:
       - name: 📦 Release
         run: yarn release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       


### PR DESCRIPTION
Because the branch is protected semantic release needs the token to allow it to commit to it. Hopefully this works as I am not able to test this beforehand.