### PR TITLE
chore: fix release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: push
+name: release
 on:
   push:
     branches: [staging, develop]
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: 💿 Setup Nodejs
         uses: actions/setup-node@v3
@@ -52,5 +52,6 @@ jobs:
       - name: 📦 Release
         run: yarn release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       


### PR DESCRIPTION
I am trying to fix that failing action that will automatically increment the app package version and publish a changelog.
Now for that because the branch is protected a separate github token must be created with proper perms by somebody that has admin right on the repo/organization and that add it to the repo secrets.

Call it GH_TOKEN with perms listed in this link:
https://github.com/semantic-release/github#github-authentication