### PR TITLE
Fetch collator identities

### DIFF
--- a/src/components/Skeleton/index.tsx
+++ b/src/components/Skeleton/index.tsx
@@ -5,7 +5,7 @@ export type SkeletonProps = {
 } & Omit<HTMLAttributes<HTMLDivElement>, 'style'>;
 
 export const Skeleton = ({ className, children, ...rest }: SkeletonProps) => (
-  <div {...rest} className={`bg-gray-100 rounded-lg ${className} animate-pulse`}>
+  <div {...rest} className={`bg-base-300 rounded-lg ${className} animate-pulse`}>
     <div className="invisible">{children}</div>
   </div>
 );

--- a/src/hooks/useIdentityPallet.ts
+++ b/src/hooks/useIdentityPallet.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'preact/hooks';
+import { useNodeInfoState } from '../NodeInfoProvider';
+
+export interface PalletIdentityInfo {
+  email?: string;
+  riot?: string;
+  twitter?: string;
+  web?: string;
+  display?: string;
+}
+
+export function useIdentityPallet() {
+  const { api } = useNodeInfoState().state;
+
+  const memo = useMemo(() => {
+    return {
+      async identityOf(account: string): Promise<PalletIdentityInfo | undefined> {
+        if (!api || !api.query.identity) {
+          return;
+        }
+        const indentityResponse = await api.query.identity.identityOf(account);
+        if (indentityResponse.isEmpty) {
+          return;
+        }
+        // Casting the data to the real value PalletIdentityRegistration, fails to show readable info
+        // Therefore the cast to 'any'
+        const pir: any = indentityResponse.toHuman();
+        return {
+          email: pir.info.email ? pir.info.email.Raw : '',
+          riot: pir.info.riot? pir.info.riot.Raw : '',
+          twitter: pir.info.twitter? pir.info.twitter.Raw: '',
+          web: pir.info.web? pir.info.web.Raw : '',
+          display: pir.info.display? pir.info.display.Raw : '',
+        };
+      }
+    };
+  }, [api]);
+
+  return memo;
+}

--- a/src/hooks/useIdentityPallet.ts
+++ b/src/hooks/useIdentityPallet.ts
@@ -1,12 +1,14 @@
+import { PalletIdentityRegistration } from '@polkadot/types/lookup';
+import { hexToU8a } from '@polkadot/util';
 import { useMemo } from 'preact/hooks';
 import { useNodeInfoState } from '../NodeInfoProvider';
 
 export interface PalletIdentityInfo {
+  display?: string;
   email?: string;
   riot?: string;
   twitter?: string;
   web?: string;
-  display?: string;
 }
 
 export function useIdentityPallet() {
@@ -22,15 +24,16 @@ export function useIdentityPallet() {
         if (indentityResponse.isEmpty) {
           return;
         }
+        
         // Casting the data to the real value PalletIdentityRegistration, fails to show readable info
         // Therefore the cast to 'any'
-        const pir: any = indentityResponse.toHuman();
+        const pir: any = indentityResponse.toHuman() as unknown as PalletIdentityRegistration;
         return {
+          display: pir.info.display? pir.info.display.Raw : '',
           email: pir.info.email ? pir.info.email.Raw : '',
           riot: pir.info.riot? pir.info.riot.Raw : '',
           twitter: pir.info.twitter? pir.info.twitter.Raw: '',
           web: pir.info.web? pir.info.web.Raw : '',
-          display: pir.info.display? pir.info.display.Raw : '',
         };
       }
     };

--- a/src/hooks/useIdentityPallet.ts
+++ b/src/hooks/useIdentityPallet.ts
@@ -20,14 +20,14 @@ export function useIdentityPallet() {
         if (!api || !api.query.identity) {
           return;
         }
-        const indentityResponse = await api.query.identity.identityOf(account);
-        if (indentityResponse.isEmpty) {
+        const identityResponse = await api.query.identity.identityOf(account);
+        if (identityResponse.isEmpty) {
           return;
         }
         
         // Casting the data to the real value PalletIdentityRegistration, fails to show readable info
         // Therefore the cast to 'any'
-        const pir: any = indentityResponse.toHuman() as unknown as PalletIdentityRegistration;
+        const pir: any = identityResponse.toHuman() as unknown as PalletIdentityRegistration;
         return {
           display: pir.info.display? pir.info.display.Raw : '',
           email: pir.info.email ? pir.info.email.Raw : '',

--- a/src/pages/collators/Collators.tsx
+++ b/src/pages/collators/Collators.tsx
@@ -20,12 +20,15 @@ import {
 } from './columns';
 import ClaimRewardsDialog from './dialogs/ClaimRewardsDialog';
 import ExecuteDelegationDialogs from './dialogs/ExecuteDelegationDialogs';
+import { PalletIdentityInfo, useIdentityPallet } from '../../hooks/useIdentityPallet';
+import { PalletIdentityRegistrarInfo } from '@polkadot/types/lookup';
 
 function Collators() {
   const { api, tokenSymbol, ss58Format } = useNodeInfoState().state;
   const { walletAccount } = useGlobalState();
 
   const { candidates, inflationInfo, estimatedRewards } = useStakingPallet();
+  const { identityOf } = useIdentityPallet();
 
   // Holds the candidate for which the delegation modal is to be shown
   const [selectedCandidate, setSelectedCandidate] = useState<ParachainStakingCandidate | undefined>(undefined);
@@ -34,6 +37,7 @@ function Collators() {
   const [userStaking, setUserStaking] = useState<UserStaking>();
   const [claimDialogOpen, setClaimDialogOpen] = useState<boolean>(false);
   const [unbonding, setUnbonding] = useState<boolean>(false);
+  const [data, setData] = useState<TCollator[] | undefined>();
 
   const userAccountAddress = useMemo(() => {
     return walletAccount && ss58Format ? getAddressForFormat(walletAccount?.address, ss58Format) : '';
@@ -64,19 +68,37 @@ function Collators() {
     fetchAvailableBalance().then((balance) => setUserAvailableBalance(balance));
   }, [api, walletAccount]);
 
-  const data = useMemo<TCollator[] | undefined>(
-    () =>
-      candidates?.map((candidate) => {
-        return {
-          candidate: candidate,
-          collator: candidate.id,
-          totalStaked: nativeToFormat(candidate.total, tokenSymbol),
-          delegators: candidate.delegators.length,
-          apy: inflationInfo?.delegator.rewardRate.annual || '0.00%',
-        };
-      }),
-    [candidates, inflationInfo?.delegator.rewardRate.annual, tokenSymbol],
-  );
+  useEffect(() => {
+    const identitiesPrefetch = async (candidatesArray: any) => {
+      const m: Map<string, PalletIdentityInfo | undefined> = new Map();
+      for (let i = 0; i < candidatesArray.length; i++) {
+        const c = candidatesArray[i];
+        m.set(c.id, await identityOf(c.id));
+      }
+      return m;
+    };
+
+    const decorateCandidates = (
+      candidatesArray: ParachainStakingCandidate[],
+      identities: Map<string, PalletIdentityInfo | undefined>,
+    ) => {
+      return candidatesArray?.map((candidate) => ({
+        candidate: candidate,
+        collator: candidate.id,
+        identityInfo: identities.get(candidate.id),
+        totalStaked: nativeToFormat(candidate.total, tokenSymbol),
+        delegators: candidate.delegators.length,
+        apy: inflationInfo?.delegator.rewardRate.annual || '0.00%',
+      }));
+    };
+
+    if (candidates) {
+      identitiesPrefetch(candidates).then((identitiesMap) => {
+        const d = decorateCandidates(candidates, identitiesMap);
+        setData(d);
+      });
+    }
+  }, [candidates, inflationInfo?.delegator.rewardRate.annual, tokenSymbol, identityOf]);
 
   const columns = useMemo(() => {
     return [

--- a/src/pages/collators/Collators.tsx
+++ b/src/pages/collators/Collators.tsx
@@ -97,7 +97,7 @@ function Collators() {
   return (
     <div className="overflow-x-auto collators-list-container mt-10">
       <div className="flex mb-8 justify-between">
-        <div className="card gap-0 rounded-lg text-primary-content bg-base-200 w-1/2 mr-4 collators-box">
+        <div className="card gap-0 rounded-lg bg-base-200 w-1/2 mr-4 collators-box">
           <div className="card-body">
             <h2 className="card-title">Collators</h2>
             <div className="flex flex-row">
@@ -120,7 +120,7 @@ function Collators() {
             </div>
           </div>
         </div>
-        <div className="card rounded-lg text-primary-content bg-base-200 w-1/2 ml-4 collators-box">
+        <div className="card rounded-lg bg-base-200 w-1/2 ml-4 collators-box">
           <div className="card-body">
             <h2 className="card-title">Staking Rewards</h2>
             <div className="flex flex-row">

--- a/src/pages/collators/Collators.tsx
+++ b/src/pages/collators/Collators.tsx
@@ -189,6 +189,7 @@ function Collators() {
         data={data}
         columns={columns}
         isLoading={!candidates}
+        sortBy="collator"
         search={false}
         pageSize={8}
       />

--- a/src/pages/collators/columns.tsx
+++ b/src/pages/collators/columns.tsx
@@ -31,7 +31,7 @@ export const nameColumn: ColumnDef<TCollator> = {
   cell: ({ row }) => {
     return (
       <div className="flex flex-row">
-        <div className="mr-2">{row.original.identityInfo ? row.original.identityInfo.display : 'Unknown' + ' |'}</div>
+        <div className="mr-2">{(row.original.identityInfo ? row.original.identityInfo.display : 'Unknown') + ' |'}</div>
         <CopyableAddress publicKey={row.original.candidate.id} variant="short" inline />
       </div>
     );

--- a/src/pages/collators/columns.tsx
+++ b/src/pages/collators/columns.tsx
@@ -28,6 +28,7 @@ const getAmountDelegated = (candidate: ParachainStakingCandidate, address: strin
 export const nameColumn: ColumnDef<TCollator> = {
   header: 'Collator',
   accessorKey: 'collator',
+  accessorFn: ({ identityInfo }) => identityInfo?.display || '0',
   cell: ({ row }) => {
     return (
       <div className="flex flex-row">

--- a/src/pages/collators/columns.tsx
+++ b/src/pages/collators/columns.tsx
@@ -5,6 +5,7 @@ import { Button } from 'react-daisyui';
 import UnlinkIcon from '../../assets/UnlinkIcon';
 import { nativeToFormat } from '../../helpers/parseNumbers';
 import { ParachainStakingCandidate } from '../../hooks/staking/staking';
+import { PalletIdentityInfo } from '../../hooks/useIdentityPallet';
 
 export interface TCollator {
   candidate: ParachainStakingCandidate;
@@ -12,6 +13,7 @@ export interface TCollator {
   totalStaked: string;
   delegators: number;
   apy: string;
+  identityInfo?: PalletIdentityInfo;
 }
 
 export interface UserStaking {
@@ -25,6 +27,9 @@ const getAmountDelegated = (candidate: ParachainStakingCandidate, address: strin
 export const nameColumn: ColumnDef<TCollator> = {
   header: 'Collator',
   accessorKey: 'collator',
+  accessorFn: (c) => {
+    return c.identityInfo?.email || c.identityInfo?.twitter || c.candidate.id;
+  },
 };
 
 export const stakedColumn: ColumnDef<TCollator> = {

--- a/src/pages/collators/columns.tsx
+++ b/src/pages/collators/columns.tsx
@@ -3,6 +3,7 @@ import { ColumnDef } from '@tanstack/table-core';
 import { StateUpdater } from 'preact/hooks';
 import { Button } from 'react-daisyui';
 import UnlinkIcon from '../../assets/UnlinkIcon';
+import { CopyableAddress } from '../../components/PublicKey';
 import { nativeToFormat } from '../../helpers/parseNumbers';
 import { ParachainStakingCandidate } from '../../hooks/staking/staking';
 import { PalletIdentityInfo } from '../../hooks/useIdentityPallet';
@@ -27,8 +28,13 @@ const getAmountDelegated = (candidate: ParachainStakingCandidate, address: strin
 export const nameColumn: ColumnDef<TCollator> = {
   header: 'Collator',
   accessorKey: 'collator',
-  accessorFn: (c) => {
-    return c.identityInfo?.display || c.identityInfo?.email || c.identityInfo?.twitter || c.candidate.id;
+  cell: ({ row }) => {
+    return (
+      <div className="flex flex-row">
+        <div className="mr-2">{row.original.identityInfo ? row.original.identityInfo.display : 'Unknown' + ' |'}</div>
+        <CopyableAddress publicKey={row.original.candidate.id} variant="short" inline />
+      </div>
+    );
   },
 };
 

--- a/src/pages/collators/columns.tsx
+++ b/src/pages/collators/columns.tsx
@@ -28,7 +28,7 @@ export const nameColumn: ColumnDef<TCollator> = {
   header: 'Collator',
   accessorKey: 'collator',
   accessorFn: (c) => {
-    return c.identityInfo?.email || c.identityInfo?.twitter || c.candidate.id;
+    return c.identityInfo?.display || c.identityInfo?.email || c.identityInfo?.twitter || c.candidate.id;
   },
 };
 


### PR DESCRIPTION
- Added usePalletIdentity hook
- Added a function to fetch the identity info of a single account address
- Pre fetch identities for all collators to show in the table
  - **Note**: this slows down the loading of the table a bit, if we want to make it non-blocking, then the collators name column would remain empty for some time which is also bad UX.
-  Collator column shows (in the following order, if first is missing): display > email > twitter > account id