### PR TITLE
Wrap currency conversion with try-catch

### DIFF
--- a/src/helpers/spacewalk.ts
+++ b/src/helpers/spacewalk.ts
@@ -31,17 +31,23 @@ export function convertCurrencyToStellarAsset(currency: SpacewalkPrimitivesCurre
 
   const stellarAsset = currency.asStellar;
 
-  if (stellarAsset.isStellarNative) {
-    return Asset.native();
-  } else if (stellarAsset.isAlphaNum4) {
-    const code = hex_to_ascii(stellarAsset.asAlphaNum4.code.toHex());
-    const issuer = convertRawHexKeyToPublicKey(stellarAsset.asAlphaNum4.issuer.toHex());
-    return new Asset(code, issuer.publicKey());
-  } else if (stellarAsset.isAlphaNum12) {
-    const code = hex_to_ascii(stellarAsset.asAlphaNum12.code.toHex());
-    const issuer = convertRawHexKeyToPublicKey(stellarAsset.asAlphaNum12.issuer.toHex());
-    return new Asset(code, issuer.publicKey());
-  } else {
+  try {
+    if (stellarAsset.isStellarNative) {
+      return Asset.native();
+    } else if (stellarAsset.isAlphaNum4) {
+      const code = hex_to_ascii(stellarAsset.asAlphaNum4.code.toHex());
+      console.log('code', code);
+      const issuer = convertRawHexKeyToPublicKey(stellarAsset.asAlphaNum4.issuer.toHex());
+      return new Asset(code, issuer.publicKey());
+    } else if (stellarAsset.isAlphaNum12) {
+      const code = hex_to_ascii(stellarAsset.asAlphaNum12.code.toHex());
+      const issuer = convertRawHexKeyToPublicKey(stellarAsset.asAlphaNum12.issuer.toHex());
+      return new Asset(code, issuer.publicKey());
+    } else {
+      return null;
+    }
+  } catch (e) {
+    console.error('Error converting currency to stellar asset', e);
     return null;
   }
 }


### PR DESCRIPTION
Fixes the issue with currencies not shown on Amplitude. The problem is that currently, on-chain there are assets with a code that have a space character, but the stellar-sdk won't create `Asset`s that contain a space character. 
Because the space character on-chain is problematic in the first place, we don't want/need to handle that edge case and instead don't show these assets.