### PR TITLE
Fix xlm dialog

### DIFF
--- a/src/components/TransferCountdown/index.tsx
+++ b/src/components/TransferCountdown/index.tsx
@@ -38,9 +38,9 @@ const TransferCountdown = ({ request }: TransferCountdownProps) => {
       const newDeadlineString = deadline
         .diff(DateTime.now())
         .toFormat('hh:1mm:2ss:3')
-        .replace(':1', ' h')
-        .replace(':2', ' m')
-        .replace(':3', ' s');
+        .replace(':1', 'h ')
+        .replace(':2', 'm ')
+        .replace(':3', 's ');
       setRemainingDurationString(newDeadlineString);
     });
 

--- a/src/pages/bridge/Issue.tsx
+++ b/src/pages/bridge/Issue.tsx
@@ -392,8 +392,8 @@ function Issue(props: IssueProps): JSX.Element {
                   if (!isCompatibleStellarAmount(value)) {
                     return 'Max 7 decimals';
                   }
-                  if (parseFloat(value) > parseFloat(selectedVault?.redeemableTokens?.toString() || '0')) {
-                    return 'Amount is higher than the vault can redeem.';
+                  if (parseFloat(value) > parseFloat(selectedVault?.issuableTokens?.toString() || '0')) {
+                    return 'Amount is higher than the vault can issue.';
                   }
                 },
               }}

--- a/src/pages/bridge/TransferDialog.tsx
+++ b/src/pages/bridge/TransferDialog.tsx
@@ -112,7 +112,7 @@ interface TransferDialogProps {
 
 export function CompletedTransferDialog(props: TransferDialogProps) {
   const { transfer, visible, onClose } = props;
-  const stellarAsset = transfer.original.asset.asStellar.asAlphaNum4.code.toHuman()?.toString();
+  const stellarAsset = currencyToString(transfer.original.asset);
   const content = (
     <>
       <div className="text-md">{`You have received  ${transfer.amount} ${stellarAsset}`}</div>
@@ -139,7 +139,7 @@ export function CompletedTransferDialog(props: TransferDialogProps) {
 
 export function CancelledTransferDialog(props: TransferDialogProps) {
   const { transfer, visible, onClose } = props;
-  const stellarAsset = transfer.original.asset.asStellar.asAlphaNum4.code.toHuman()?.toString();
+  const stellarAsset = currencyToString(transfer.original.asset);
   const amountToSend = nativeToDecimal(transfer.original.amount.add(transfer.original.fee).toNumber()).toNumber();
   const content = (
     <>
@@ -175,7 +175,7 @@ export function ReimbursedTransferDialog(props: TransferDialogProps) {
   const { transfer, visible, onClose } = props;
   const tenant = useGlobalState().state.tenantName;
 
-  const stellarAsset = transfer.original.asset.asStellar.asAlphaNum4.code.toHuman()?.toString();
+  const stellarAsset = currencyToString(transfer.original.asset);
   const collateralAsset = transfer.original.vault.currencies.collateral;
 
   const content = (
@@ -208,18 +208,20 @@ export function ReimbursedTransferDialog(props: TransferDialogProps) {
 
 export function PendingTransferDialog(props: TransferDialogProps) {
   const { transfer, visible, onClose } = props;
-  const stellarAsset = transfer.original.asset.asStellar.asAlphaNum4.code.toHuman()?.toString();
+  const stellarAsset = currencyToString(transfer.original.asset);
   const vaultStellarAddress = convertRawHexKeyToPublicKey(transfer.original.vault.accountId.toHex());
   const amountToSend = nativeToDecimal(transfer.original.amount.add(transfer.original.fee).toNumber());
   const { getActiveBlockNumber } = useSecurityPallet();
   const [, setDeadline] = useState<DateTime>();
+
   useEffect(() => {
     getActiveBlockNumber().then((active) => {
       setDeadline(
         calculateDeadline(active as number, transfer.original.opentime.toNumber(), transfer.original.period.toNumber()),
       );
     });
-  }, [setDeadline]);
+  }, [getActiveBlockNumber, setDeadline, transfer.original.opentime, transfer.original.period]);
+
   const issueContent = (
     <>
       <>
@@ -276,7 +278,7 @@ export function PendingTransferDialog(props: TransferDialogProps) {
 
 export function FailedTransferDialog(props: TransferDialogProps) {
   const { transfer, visible, onClose } = props;
-  const stellarAsset = transfer.original.asset.asStellar.asAlphaNum4.code.toHuman()?.toString();
+  const stellarAsset = currencyToString(transfer.original.asset);
   const amountToSend = nativeToDecimal(transfer.original.amount.add(transfer.original.fee).toNumber()).toNumber();
   const compensation = 0.05;
   const content = (

--- a/src/pages/bridge/TransferDialog.tsx
+++ b/src/pages/bridge/TransferDialog.tsx
@@ -222,6 +222,11 @@ export function PendingTransferDialog(props: TransferDialogProps) {
     });
   }, [getActiveBlockNumber, setDeadline, transfer.original.opentime, transfer.original.period]);
 
+  const expectedStellarMemo = useMemo(() => {
+    // For issue requests we use a shorter identifier for the memo
+    return deriveShortenedRequestId(hexToU8a(transfer.transactionId));
+  }, [transfer]);
+
   const issueContent = (
     <>
       <>
@@ -229,7 +234,11 @@ export function PendingTransferDialog(props: TransferDialogProps) {
           className="text-xl"
           title={amountToSend.toString()}
         >{`Send ${amountToSend.toNumber()} ${stellarAsset}`}</div>
-        <div className="mt-1" />
+        <div className="mt-2" />
+        <div className="text">With the text memo</div>
+        <div className="mt-2" />
+        <CopyableAddress inline={true} variant="short" publicKey={expectedStellarMemo} />
+        <div className="mt-2" />
         <div className="text-md">In a single transaction to</div>
         <div className="mt-2" />
         <CopyableAddress
@@ -238,8 +247,7 @@ export function PendingTransferDialog(props: TransferDialogProps) {
           variant="short"
           publicKey={vaultStellarAddress.publicKey()}
         />
-        <div className="mt-2" />
-        <div className="text-sm">
+        <div className="text-md mt-2">
           Within <TransferCountdown request={transfer.original} />
         </div>
       </>


### PR DESCRIPTION
Closes #161 and closes #162.

Also shows the instruction to include the memo in the 'Pending' dialog on the transfers page. (I think otherwise it's not really clear that you need to include that if a user misses sending it with the first dialog and then tries to re-do it by looking at the transfers page.)

Also fixes an issue with the validation of the issue amount and changes the spacing of the transfers countdown.