### PR TITLE
Fix wrong parameter used for deriving a vault's Stellar address

### DIFF
--- a/src/pages/bridge/TransferDialog.tsx
+++ b/src/pages/bridge/TransferDialog.tsx
@@ -18,6 +18,7 @@ import CancelledDialogIcon from '../../assets/dialog-status-cancelled';
 import WarningDialogIcon from '../../assets/dialog-status-warning';
 import TransferCountdown from '../../components/TransferCountdown';
 import { useVaultRegistryPallet } from '../../hooks/spacewalk/vaultRegistry';
+import { toTitle } from '../../helpers/string';
 
 interface BaseTransferDialogProps {
   id: string;
@@ -43,7 +44,7 @@ function BaseTransferDialog(props: BaseTransferDialogProps) {
   const { id, statusIcon, showMemo, transfer, visible, title, content, footer, actions, onClose, onConfirm } = props;
 
   const { tenantName } = useGlobalState().state;
-  const tenantNameCapitalized = tenantName ? tenantName.charAt(0).toUpperCase() + tenantName.slice(1) : 'Pendulum';
+  const tenantNameCapitalized = tenantName ? toTitle(tenantName) : 'Pendulum';
 
   const [vaultStellarPublicKey, setVaultStellarPublicKey] = useState<string | undefined>(undefined);
 

--- a/src/pages/bridge/TransferDialog.tsx
+++ b/src/pages/bridge/TransferDialog.tsx
@@ -40,7 +40,7 @@ const defaultActions = (onConfirm: (() => void) | undefined) => (
 
 function BaseTransferDialog(props: BaseTransferDialogProps) {
   const { id, statusIcon, showMemo, transfer, visible, title, content, footer, actions, onClose, onConfirm } = props;
-  const vaultStellarAddress = convertRawHexKeyToPublicKey(transfer.original.vault.accountId.toHex()).publicKey();
+  const vaultStellarAddress = convertRawHexKeyToPublicKey(transfer.original.stellarAddress.toHex()).publicKey();
 
   const expectedStellarMemo = useMemo(() => {
     return deriveShortenedRequestId(hexToU8a(transfer.transactionId));

--- a/src/pages/bridge/TransferDialog.tsx
+++ b/src/pages/bridge/TransferDialog.tsx
@@ -40,7 +40,12 @@ const defaultActions = (onConfirm: (() => void) | undefined) => (
 
 function BaseTransferDialog(props: BaseTransferDialogProps) {
   const { id, statusIcon, showMemo, transfer, visible, title, content, footer, actions, onClose, onConfirm } = props;
-  const vaultStellarAddress = convertRawHexKeyToPublicKey(transfer.original.stellarAddress.toHex()).publicKey();
+
+  const { tenantName } = useGlobalState().state;
+  const tenantNameCapitalized = tenantName ? tenantName.charAt(0).toUpperCase() + tenantName.slice(1) : 'Pendulum';
+
+  // The `stellarAddress` contained in the request will either be the vault's or the user's Stellar address depending on the transfer type.
+  const destinationStellarAddress = convertRawHexKeyToPublicKey(transfer.original.stellarAddress.toHex()).publicKey();
 
   const expectedStellarMemo = useMemo(() => {
     return deriveShortenedRequestId(hexToU8a(transfer.transactionId));
@@ -61,26 +66,22 @@ function BaseTransferDialog(props: BaseTransferDialogProps) {
               <div className="text-sm">{nativeToDecimal(transfer.original.fee.toNumber()).toString()}</div>
             </div>
             <div className="flex flex-row justify-between">
-              <div className="text-sm">Destination Address</div>
+              <div className="text-sm">Destination Address (Stellar)</div>
               <CopyableAddress
                 inline={true}
                 className="text-sm p0"
                 variant="short"
-                publicKey={convertRawHexKeyToPublicKey(transfer.original.stellarAddress.toString()).publicKey()}
+                publicKey={destinationStellarAddress}
               />
             </div>
             <div className="flex flex-row justify-between">
-              <div className="text-sm">Vault Address</div>
+              <div className="text-sm">Vault Address ({tenantNameCapitalized})</div>
               <CopyableAddress
                 inline={true}
                 className="text-sm p-0"
                 variant="short"
                 publicKey={transfer.original.vault.accountId.toString()}
               />
-            </div>
-            <div className="flex flex-row justify-between">
-              <div className="text-sm">Vault Stellar Address</div>
-              <CopyableAddress inline={true} className="text-sm p-0" variant="short" publicKey={vaultStellarAddress} />
             </div>
             {showMemo && (
               <div className="flex flex-row justify-between">

--- a/src/pages/bridge/TransferDialog.tsx
+++ b/src/pages/bridge/TransferDialog.tsx
@@ -209,7 +209,7 @@ export function ReimbursedTransferDialog(props: TransferDialogProps) {
 export function PendingTransferDialog(props: TransferDialogProps) {
   const { transfer, visible, onClose } = props;
   const stellarAsset = currencyToString(transfer.original.asset);
-  const vaultStellarAddress = convertRawHexKeyToPublicKey(transfer.original.vault.accountId.toHex());
+  const vaultStellarAddress = convertRawHexKeyToPublicKey(transfer.original.stellarAddress.toHex()).publicKey();
   const amountToSend = nativeToDecimal(transfer.original.amount.add(transfer.original.fee).toNumber());
   const { getActiveBlockNumber } = useSecurityPallet();
   const [, setDeadline] = useState<DateTime>();
@@ -241,12 +241,7 @@ export function PendingTransferDialog(props: TransferDialogProps) {
         <div className="mt-2" />
         <div className="text-md">In a single transaction to</div>
         <div className="mt-2" />
-        <CopyableAddress
-          inline={true}
-          className="text-sm p-0"
-          variant="short"
-          publicKey={vaultStellarAddress.publicKey()}
-        />
+        <CopyableAddress inline={true} className="text-sm p-0" variant="short" publicKey={vaultStellarAddress} />
         <div className="text-md mt-2">
           Within <TransferCountdown request={transfer.original} />
         </div>

--- a/src/pages/bridge/TransferDialog.tsx
+++ b/src/pages/bridge/TransferDialog.tsx
@@ -1,5 +1,8 @@
 import { Button, Divider, Modal } from 'react-daisyui';
+import { useEffect, useMemo, useState } from 'react';
 import { h } from 'preact';
+import { DateTime } from 'luxon';
+import { hexToU8a } from '@polkadot/util';
 import { CloseButton } from '../../components/CloseButton';
 import SuccessDialogIcon from '../../assets/dialog-status-success';
 import PendingDialogIcon from '../../assets/dialog-status-pending';
@@ -11,12 +14,9 @@ import { convertRawHexKeyToPublicKey } from '../../helpers/stellar';
 import { useGlobalState } from '../../GlobalStateProvider';
 import { useSecurityPallet } from '../../hooks/spacewalk/security';
 import { calculateDeadline, currencyToString, deriveShortenedRequestId } from '../../helpers/spacewalk';
-import { useEffect, useMemo, useState } from 'react';
-import { DateTime } from 'luxon';
 import CancelledDialogIcon from '../../assets/dialog-status-cancelled';
 import WarningDialogIcon from '../../assets/dialog-status-warning';
 import TransferCountdown from '../../components/TransferCountdown';
-import { hexToU8a } from '@polkadot/util';
 import { useVaultRegistryPallet } from '../../hooks/spacewalk/vaultRegistry';
 
 interface BaseTransferDialogProps {
@@ -238,7 +238,7 @@ export function ReimbursedTransferDialog(props: TransferDialogProps) {
 export function PendingTransferDialog(props: TransferDialogProps) {
   const { transfer, visible, onClose } = props;
   const stellarAsset = currencyToString(transfer.original.asset);
-  const vaultStellarAddress = convertRawHexKeyToPublicKey(transfer.original.stellarAddress.toHex()).publicKey();
+  const destinationStellarAddress = convertRawHexKeyToPublicKey(transfer.original.stellarAddress.toHex()).publicKey();
   const amountToSend = nativeToDecimal(transfer.original.amount.add(transfer.original.fee).toNumber());
   const { getActiveBlockNumber } = useSecurityPallet();
   const [, setDeadline] = useState<DateTime>();
@@ -270,7 +270,7 @@ export function PendingTransferDialog(props: TransferDialogProps) {
         <div className="mt-2" />
         <div className="text-md">In a single transaction to</div>
         <div className="mt-2" />
-        <CopyableAddress inline={true} className="text-sm p-0" variant="short" publicKey={vaultStellarAddress} />
+        <CopyableAddress inline={true} className="text-sm p-0" variant="short" publicKey={destinationStellarAddress} />
         <div className="text-md mt-2">
           Within <TransferCountdown request={transfer.original} />
         </div>


### PR DESCRIPTION
Fixes [this](https://github.com/pendulum-chain/tasks/issues/65) issue.

I changed the namings in the dialog a bit to make it clearer which address/account ID belongs to which network (Stellar vs parachain).