### PR TITLE
add expiry date to local storage hooks

### DIFF
--- a/src/GlobalStateProvider.tsx
+++ b/src/GlobalStateProvider.tsx
@@ -73,6 +73,7 @@ const GlobalStateProvider = ({
 
   useEffect(() => {
     const run = async () => {
+      storageService.removeExpired();
       if (!account) return;
       const name = storageService.get('@talisman-connect/selected-wallet-name');
       if (!name) return;

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -2,4 +2,5 @@ export const storageKeys = {
   ACCOUNT: 'ACCOUNT',
   SWAP_SETTINGS: 'SWAP_SETTINGS',
   GLOBAL: 'GLOBAL',
+  EXPIRY_DATE: '_EXPIRY_DATE'
 };

--- a/src/services/storage/local.ts
+++ b/src/services/storage/local.ts
@@ -1,4 +1,6 @@
+import { DateTime } from 'luxon';
 import { Storage } from './types';
+import { storageKeys } from '../../constants/localStorage';
 
 const exists = (value?: string | null): value is string => !!value && value.length > 0;
 export const storageService: Storage = {
@@ -28,4 +30,19 @@ export const storageService: Storage = {
     ),
 
   remove: (key) => localStorage?.removeItem(key),
+
+  removeExpired: () => {
+    const keys = {...localStorage};
+    for (const key in keys) {
+      if (key.endsWith(storageKeys.EXPIRY_DATE)) {
+        const item = localStorage.getItem(key) || '';
+        if (item && Date.now() > (new Date(JSON.parse(item)).getDate())) {
+          const originalKey = key.replace(storageKeys.EXPIRY_DATE,''); 
+          console.log("Removing " + originalKey + "from local storage");
+          localStorage.removeItem(originalKey);
+          localStorage.removeItem(key);
+        }
+      }
+    }
+  }
 };

--- a/src/services/storage/types.ts
+++ b/src/services/storage/types.ts
@@ -5,4 +5,5 @@ export interface Storage {
   getBoolean: (key: string) => boolean | undefined;
   set: (key: string, value: unknown) => void;
   remove: (key: string) => void;
+  removeExpired: () => void;
 }


### PR DESCRIPTION
Adds an expiry date option to items in local storage.
- It adds another item to local storage to save the expire date for that item
- I wasn't sure where to put it, so I placed it while rendering the `GlobalStateProvider`
- Not very secure since users can change expire date from storage, so we don't need to rely on this mechanism for anything else than simple usage