### PR TITLE
organize imports in the project

### DIFF
--- a/src/NodeInfoProvider.tsx
+++ b/src/NodeInfoProvider.tsx
@@ -1,9 +1,9 @@
 import { options } from '@pendulum-chain/api';
 import { rpc } from '@pendulum-chain/types';
-import { toast } from 'react-toastify';
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { createContext } from 'preact';
 import { useContext, useEffect, useState } from 'preact/hooks';
+import { toast } from 'react-toastify';
 
 export interface NodeInfoProviderInterface {
   bestNumberFinalize?: number;

--- a/src/assets/CopyIcon.tsx
+++ b/src/assets/CopyIcon.tsx
@@ -1,5 +1,3 @@
-import { h } from 'preact';
-
 interface Props {
   className?: string;
 }

--- a/src/assets/socials-telegram.tsx
+++ b/src/assets/socials-telegram.tsx
@@ -1,5 +1,3 @@
-import { h } from 'preact';
-
 const TelegramLogo = () => (
   <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
     <g clipPath="url(#clip0_614_2493)">

--- a/src/components/LabelledSelector/index.tsx
+++ b/src/components/LabelledSelector/index.tsx
@@ -1,7 +1,6 @@
-import { Select } from 'react-daisyui';
-import { h } from 'preact';
-import { ofSelect } from '../../helpers/general';
 import { ChangeEvent, CSSProperties } from 'preact/compat';
+import { Select } from 'react-daisyui';
+import { ofSelect } from '../../helpers/general';
 
 interface Props<T> {
   items: T[];

--- a/src/components/Layout/Versions.tsx
+++ b/src/components/Layout/Versions.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { FC, memo } from 'preact/compat';
-import { TenantName } from '../../models/Tenant';
 import { useNodeInfoState } from '../../NodeInfoProvider';
+import { TenantName } from '../../models/Tenant';
 
 interface Props {
   tenantName: TenantName | undefined;

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -1,5 +1,3 @@
-import { h } from 'preact';
-
 export function NotFound() {
   return <h1>NotFound</h1>;
 }

--- a/src/components/Selector/AssetSelector.tsx
+++ b/src/components/Selector/AssetSelector.tsx
@@ -1,8 +1,7 @@
+import { CSSProperties } from 'preact/compat';
 import { Asset } from 'stellar-sdk';
 import { stringifyStellarAsset } from '../../helpers/stellar';
 import LabelledSelector from './LabelledSelector';
-import { h } from 'preact';
-import { CSSProperties } from 'preact/compat';
 
 interface AssetSelectorProps {
   selectedAsset?: Asset;

--- a/src/components/Selector/LabelledSelector.tsx
+++ b/src/components/Selector/LabelledSelector.tsx
@@ -1,6 +1,5 @@
-import { ChangeEvent } from 'preact/compat';
+import { CSSProperties, ChangeEvent } from 'preact/compat';
 import { Select } from 'react-daisyui';
-import { CSSProperties } from 'preact/compat';
 import { ofSelect } from '../../helpers/general';
 
 interface Item {

--- a/src/components/Selector/VaultSelector.tsx
+++ b/src/components/Selector/VaultSelector.tsx
@@ -1,10 +1,9 @@
-import { ExtendedRegistryVault } from '../../hooks/spacewalk/vaultRegistry';
-import { h } from 'preact';
-import { PublicKey } from '../PublicKey';
-import { convertCurrencyToStellarAsset } from '../../helpers/spacewalk';
-import { Button, Dropdown } from 'react-daisyui';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
+import { Button, Dropdown } from 'react-daisyui';
 import { nativeToDecimal } from '../../helpers/parseNumbers';
+import { convertCurrencyToStellarAsset } from '../../helpers/spacewalk';
+import { ExtendedRegistryVault } from '../../hooks/spacewalk/vaultRegistry';
+import { PublicKey } from '../PublicKey';
 
 interface VaultSelectorProps {
   vaults: ExtendedRegistryVault[];

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,5 +1,4 @@
 import { FC } from 'preact/compat';
-import { h } from 'preact';
 
 import './styles.css';
 

--- a/src/components/TickerChangeTable/index.tsx
+++ b/src/components/TickerChangeTable/index.tsx
@@ -1,6 +1,5 @@
-import { h } from 'preact';
-import './styles.css';
 import usdc from '../../assets/usdc.png';
+import './styles.css';
 
 const TickerChangeTable = () => (
   <div className="ticker-change-table" style={{ marginTop: 40 }}>

--- a/src/hooks/spacewalk/fee.tsx
+++ b/src/hooks/spacewalk/fee.tsx
@@ -2,8 +2,8 @@ import { SubmittableExtrinsic } from '@polkadot/api/promise/types';
 import { SpacewalkPrimitivesCurrencyId } from '@polkadot/types/lookup';
 import Big from 'big.js';
 import { useEffect, useMemo, useState } from 'preact/hooks';
-import { fixedPointToDecimal } from '../../helpers/parseNumbers';
 import { useNodeInfoState } from '../../NodeInfoProvider';
+import { fixedPointToDecimal } from '../../helpers/parseNumbers';
 
 export function useFeePallet() {
   const [issueFee, setIssueFee] = useState<Big>(new Big(0));

--- a/src/hooks/spacewalk/issue.tsx
+++ b/src/hooks/spacewalk/issue.tsx
@@ -1,7 +1,7 @@
+import { H256 } from '@polkadot/types/interfaces';
 import type { SpacewalkPrimitivesIssueIssueRequest, SpacewalkPrimitivesVaultId } from '@polkadot/types/lookup';
 import { useMemo } from 'preact/hooks';
 import { useNodeInfoState } from '../../NodeInfoProvider';
-import { H256 } from '@polkadot/types/interfaces';
 
 export interface RichIssueRequest {
   id: H256;

--- a/src/hooks/spacewalk/redeem.tsx
+++ b/src/hooks/spacewalk/redeem.tsx
@@ -1,7 +1,7 @@
+import { H256 } from '@polkadot/types/interfaces';
 import type { SpacewalkPrimitivesRedeemRedeemRequest, SpacewalkPrimitivesVaultId } from '@polkadot/types/lookup';
 import { useMemo } from 'preact/hooks';
 import { useNodeInfoState } from '../../NodeInfoProvider';
-import { H256 } from '@polkadot/types/interfaces';
 import { convertPublicKeyToRaw } from '../../helpers/stellar';
 
 export interface RichRedeemRequest {

--- a/src/hooks/spacewalk/security.tsx
+++ b/src/hooks/spacewalk/security.tsx
@@ -1,6 +1,6 @@
+import { UnsubscribePromise } from '@polkadot/api-base/types';
 import { useMemo } from 'preact/hooks';
 import { useNodeInfoState } from '../../NodeInfoProvider';
-import { UnsubscribePromise } from '@polkadot/api-base/types';
 
 export function useSecurityPallet() {
   const { api } = useNodeInfoState().state;

--- a/src/hooks/spacewalk/vaultRegistry.tsx
+++ b/src/hooks/spacewalk/vaultRegistry.tsx
@@ -1,6 +1,6 @@
+import { AccountId32, Balance } from '@polkadot/types/interfaces';
 import type { VaultRegistryVault } from '@polkadot/types/lookup';
 import { useEffect, useMemo, useState } from 'preact/hooks';
-import { AccountId32, Balance } from '@polkadot/types/interfaces';
 import { useNodeInfoState } from '../../NodeInfoProvider';
 import { convertRawHexKeyToPublicKey } from '../../helpers/stellar';
 

--- a/src/pages/bridge/TransfersColumns.tsx
+++ b/src/pages/bridge/TransfersColumns.tsx
@@ -1,11 +1,11 @@
+import { DocumentMagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import { SpacewalkPrimitivesIssueIssueRequest, SpacewalkPrimitivesRedeemRedeemRequest } from '@polkadot/types/lookup';
 import { ColumnDef } from '@tanstack/table-core';
+import { DateTime } from 'luxon';
 import { Button } from 'react-daisyui';
 import { CopyableAddress } from '../../components/PublicKey';
-import { DateTime } from 'luxon';
-import { DocumentMagnifyingGlassIcon } from '@heroicons/react/24/outline';
-import { TenantName } from '../../models/Tenant';
 import { toTitle } from '../../helpers/string';
+import { TenantName } from '../../models/Tenant';
 export type TransferStatus = 'Pending' | 'Completed' | 'Cancelled' | 'Reimbursed' | 'Failed' | 'Retried';
 
 export enum TransferType {

--- a/src/pages/collators/dialogs/ConfirmDelegateDialog.tsx
+++ b/src/pages/collators/dialogs/ConfirmDelegateDialog.tsx
@@ -1,8 +1,7 @@
 import Big from 'big.js';
-import { nativeToDecimal } from '../../../helpers/parseNumbers';
 import { Button, Modal } from 'react-daisyui';
-import { h } from 'preact';
 import { CloseButton } from '../../../components/CloseButton';
+import { nativeToDecimal } from '../../../helpers/parseNumbers';
 import { DelegationMode } from './ExecuteDelegationDialogs';
 
 interface ConfirmDelegateDialogProps {


### PR DESCRIPTION
I noticed that we may have different settings regarding organising imports. Sometimes we might have conflicts with this, or we miss an unused import. So I run the `organise imports` action for the whole project, and I encourage you to add to your VSCode settings (if you use it) or similar:
```
"editor.codeActionsOnSave": {
  "source.organizeImports": true
}, 
```