### PR TITLE
187 change name of spacewalk tokens on UI

### DIFF
--- a/src/components/Selector/AssetSelector.tsx
+++ b/src/components/Selector/AssetSelector.tsx
@@ -9,25 +9,26 @@ interface AssetSelectorProps {
   assets: Asset[];
   style?: CSSProperties;
   assetPrefix?: string;
+  assetSuffix?: string;
 }
 
-function getDisplayName(asset: Asset, assetPrefix?: string): string {
-  return `${assetPrefix || ''}${asset.getCode()}`;
+function getDisplayName(asset: Asset, assetPrefix?: string, assetSuffix?: string): string {
+  return `${assetPrefix || ''}${asset.getCode()}${assetSuffix || ''}`;
 }
 
 function AssetSelector(props: AssetSelectorProps): JSX.Element {
-  const { assets, selectedAsset, assetPrefix } = props;
+  const { assets, selectedAsset, assetPrefix, assetSuffix } = props;
 
   const items = assets.map((asset) => {
     return {
-      displayName: getDisplayName(asset, assetPrefix),
+      displayName: getDisplayName(asset, assetPrefix, assetSuffix),
       id: stringifyStellarAsset(asset),
     };
   });
 
   const selectedAssetItem = selectedAsset
     ? {
-        displayName: getDisplayName(selectedAsset, assetPrefix),
+        displayName: getDisplayName(selectedAsset, assetPrefix, assetSuffix),
         id: stringifyStellarAsset(selectedAsset),
       }
     : undefined;

--- a/src/pages/bridge/Issue.tsx
+++ b/src/pages/bridge/Issue.tsx
@@ -31,16 +31,16 @@ interface FeeBoxProps {
   amountNative: Big;
   extrinsic?: SubmittableExtrinsic;
   network: string;
-  wrappedCurrencyPrefix?: string;
+  wrappedCurrencySuffix?: string;
   nativeCurrency: string;
 }
 
 function FeeBox(props: FeeBoxProps): JSX.Element {
-  const { bridgedAsset, extrinsic, network, wrappedCurrencyPrefix, nativeCurrency } = props;
+  const { bridgedAsset, extrinsic, network, wrappedCurrencySuffix, nativeCurrency } = props;
 
   const amount = props.amountNative;
 
-  const wrappedCurrencyName = bridgedAsset ? (wrappedCurrencyPrefix || '') + bridgedAsset.getCode() : '';
+  const wrappedCurrencyName = bridgedAsset ? bridgedAsset.getCode() + (wrappedCurrencySuffix || '') : '';
 
   const { getFees, getTransactionFee } = useFeePallet();
   const fees = getFees();
@@ -220,12 +220,12 @@ interface IssueFormInputs {
 
 interface IssueProps {
   network: string;
-  wrappedCurrencyPrefix: string;
+  wrappedCurrencySuffix: string;
   nativeCurrency: string;
 }
 
 function Issue(props: IssueProps): JSX.Element {
-  const { network, wrappedCurrencyPrefix, nativeCurrency } = props;
+  const { network, wrappedCurrencySuffix, nativeCurrency } = props;
 
   const [selectedVault, setSelectedVault] = useState<ExtendedRegistryVault>();
   const [selectedAsset, setSelectedAsset] = useState<Asset>();
@@ -463,7 +463,7 @@ function Issue(props: IssueProps): JSX.Element {
             bridgedAsset={selectedAsset}
             extrinsic={requestIssueExtrinsic}
             network={network}
-            wrappedCurrencyPrefix={wrappedCurrencyPrefix}
+            wrappedCurrencySuffix={wrappedCurrencySuffix}
             nativeCurrency={nativeCurrency}
           />
           {walletAccount ? (

--- a/src/pages/bridge/Redeem.tsx
+++ b/src/pages/bridge/Redeem.tsx
@@ -33,14 +33,14 @@ interface FeeBoxProps {
   extrinsic?: SubmittableExtrinsic;
   network: string;
   nativeCurrency: string;
-  wrappedCurrencyPrefix?: string;
+  wrappedCurrencySuffix?: string;
 }
 
 function FeeBox(props: FeeBoxProps): JSX.Element {
-  const { bridgedAsset, extrinsic, nativeCurrency, wrappedCurrencyPrefix, network } = props;
+  const { bridgedAsset, extrinsic, nativeCurrency, wrappedCurrencySuffix, network } = props;
   const amount = props.amountNative;
 
-  const wrappedCurrencyName = bridgedAsset ? (wrappedCurrencyPrefix || '') + bridgedAsset.getCode() : '';
+  const wrappedCurrencyName = bridgedAsset ? (wrappedCurrencySuffix || '') + bridgedAsset.getCode() : '';
 
   const { getFees, getTransactionFee } = useFeePallet();
   const fees = getFees();
@@ -157,7 +157,7 @@ interface RedeemFormInputs {
 
 interface RedeemProps {
   network: string;
-  wrappedCurrencyPrefix: string;
+  wrappedCurrencySuffix: string;
   nativeCurrency: string;
 }
 
@@ -182,7 +182,7 @@ function Redeem(props: RedeemProps): JSX.Element {
     },
   });
 
-  const { wrappedCurrencyPrefix, nativeCurrency } = props;
+  const { wrappedCurrencySuffix, nativeCurrency } = props;
 
   // We watch the amount because we need to re-render the FeeBox constantly
   const amount = watch('amount');
@@ -366,7 +366,7 @@ function Redeem(props: RedeemProps): JSX.Element {
             <div className="px-1" />
             {wrappedAssets && (
               <AssetSelector
-                assetPrefix={wrappedCurrencyPrefix}
+                assetSuffix={wrappedCurrencySuffix}
                 selectedAsset={selectedAsset}
                 assets={wrappedAssets}
                 onChange={setSelectedAsset}

--- a/src/pages/bridge/index.tsx
+++ b/src/pages/bridge/index.tsx
@@ -9,17 +9,17 @@ function Bridge(): JSX.Element | null {
   const [tabValue, setTabValue] = useState(0);
   const { chain } = useNodeInfoState().state;
   const nativeCurrency = chain === 'Amplitude' ? 'AMPE' : 'PEN';
-  const wrappedCurrencyPrefix = chain === 'Amplitude' ? 'a' : 'p';
+  const wrappedCurrencySuffix = '.s';
 
   const Content = useMemo(() => {
     if (!chain) return;
     switch (tabValue) {
       case 0:
-        return <Issue network={chain} nativeCurrency={nativeCurrency} wrappedCurrencyPrefix={wrappedCurrencyPrefix} />;
+        return <Issue network={chain} nativeCurrency={nativeCurrency} wrappedCurrencySuffix={wrappedCurrencySuffix} />;
       case 1:
-        return <Redeem network={chain} nativeCurrency={nativeCurrency} wrappedCurrencyPrefix={wrappedCurrencyPrefix} />;
+        return <Redeem network={chain} nativeCurrency={nativeCurrency} wrappedCurrencySuffix={wrappedCurrencySuffix} />;
     }
-  }, [chain, nativeCurrency, tabValue, wrappedCurrencyPrefix]);
+  }, [chain, nativeCurrency, tabValue, wrappedCurrencySuffix]);
 
   return chain ? (
     <div className="h-full flex items-center justify-center mt-4">


### PR DESCRIPTION
- Changed on Issue fee box
- Changed on Redeem fee box and asset selector
- Now, both Amplitude and Pendulum show the same suffix `.s`
Closes #187 