### PR TITLE
fix: release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - name: 🛒 Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: 💿 Setup Nodejs
         uses: actions/setup-node@v3


### PR DESCRIPTION
Reverted the change. I believe it is a token problem. The GH_TOKEN needs all repo permissions as this was working before.
It can be updated under the repo env variables
