### PR TITLE
Remove alpha/foucoco indicator

### DIFF
--- a/src/components/Layout/Versions.tsx
+++ b/src/components/Layout/Versions.tsx
@@ -9,29 +9,9 @@ interface Props {
 
 const Versions: FC<Props> = memo(({ tenantName }: Props) => {
   const { state } = useNodeInfoState();
-  let indicator = '';
-
-  switch (tenantName) {
-    case 'amplitude': {
-      indicator = 'alpha';
-      break;
-    }
-    case 'pendulum': {
-      indicator = '';
-      break;
-    }
-    case 'foucoco': {
-      indicator = 'Foucoco';
-      break;
-    }
-  }
-
   return (
     <div className="pendulum-versions">
-      <p>
-        <span className="text-green-300 hover:text-green-500 cursor-default mr-1">{indicator}</span>
-        Runtime: {(state.nodeVersion && state.nodeVersion.toString()) || '0.0.0-00000000000'}
-      </p>
+      <p>Runtime: {(state.nodeVersion && state.nodeVersion.toString()) || '0.0.0-00000000000'}</p>
     </div>
   );
 });


### PR DESCRIPTION
Removing the green indicators since they were a bit confusing and not part of the designs.
![Screenshot 2023-09-13 at 4 31 24 PM](https://github.com/pendulum-chain/portal/assets/4713407/b29e283b-9fac-4eab-b932-e08b40ba35fa)
![Screenshot 2023-09-13 at 4 31 01 PM](https://github.com/pendulum-chain/portal/assets/4713407/d1ab6e7d-a8c6-42e1-a011-34e8bc726c38)
