### PR TITLE
fix: Import react components from preact/compat

### DIFF
--- a/src/hooks/spacewalk/useBridgeSettings.ts
+++ b/src/hooks/spacewalk/useBridgeSettings.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import _ from 'lodash';
-import React, { StateUpdater, useEffect, useMemo, useState } from 'preact/compat';
+import { StateUpdater, useContext, useEffect, useMemo, useState } from 'preact/compat';
 import { Asset } from 'stellar-sdk';
 import { convertCurrencyToStellarAsset } from '../../helpers/spacewalk';
 import { stringifyStellarAsset } from '../../helpers/stellar';
@@ -24,7 +24,7 @@ function useBridgeSettings(): BridgeSettings {
   const [manualVaultSelection, setManualVaultSelection] = useState(false);
   const { getVaults, getVaultsWithIssuableTokens, getVaultsWithRedeemableTokens } = useVaultRegistryPallet();
   const [selectedVault, setSelectedVault] = useState<ExtendedRegistryVault>();
-  const { selectedAsset, setSelectedAsset } = (React.useContext(BridgeContext) || {}) as any;
+  const { selectedAsset, setSelectedAsset } = (useContext(BridgeContext) || {}) as any;
 
   useEffect(() => {
     const combinedVaults: ExtendedRegistryVault[] = [];

--- a/src/pages/dashboard/Portfolio.tsx
+++ b/src/pages/dashboard/Portfolio.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'preact/compat';
-import Table, { SortingOrder } from '../../components/Table';
 import { useGlobalState } from '../../GlobalStateProvider';
+import Table, { SortingOrder } from '../../components/Table';
 import useBalances from '../../hooks/useBalances';
 import { amountColumn, priceColumn, tokenColumn, usdValueColumn } from './PortfolioColumns';
 


### PR DESCRIPTION
App wise, we import hooks and components for preact/compat. The use of the _auto import_ feature from VsCode sometimes made a few exceptions, importing from react. To be consistent in our code, I removed the exceptions in this PR.