### PR TITLE
fix: Implement collapsible buttons for sidebar

### DIFF
--- a/src/components/Layout/Nav.tsx
+++ b/src/components/Layout/Nav.tsx
@@ -90,11 +90,11 @@ const Nav = memo(({ onClick }: NavProps) => {
               </>
             }
           >
-            <div className="submenu">
+            <ul className="submenu" id='submenu'>
               {item.submenu.map((subItem, j) => (
-                <NavItem key={`${i}-${j}`} item={subItem} onClick={onClick} />
+                <li key={`${i}-${j}`}><NavItem item={subItem} onClick={onClick} /></li>
               ))}
-            </div>
+            </ul>
           </CollapseMenu>
         ) : (
           <NavItem key={i} item={item} onClick={onClick} />

--- a/src/components/Layout/Nav.tsx
+++ b/src/components/Layout/Nav.tsx
@@ -53,7 +53,7 @@ const NavItem = ({ item, onClick }: { item: LinkItem; onClick?: () => void }) =>
       {suffix}
     </>
   );
-  const cls = `nav-item ${props?.className?.()}`;
+  const cls = `nav-item ${props?.className?.() || ''}`;
   return isExternal ? (
     <a href={link} {...props} className={cls} onClick={onClick}>
       {linkUi}

--- a/src/components/Layout/Nav.tsx
+++ b/src/components/Layout/Nav.tsx
@@ -9,11 +9,13 @@ const CollapseMenu = ({
   disabled,
   button,
   children,
+  ariaControls
 }: {
   link: string;
   disabled?: boolean;
   button: JSX.Element | null;
   children: JSX.Element | null;
+  ariaControls?: string;
 }) => {
   const { pathname } = useLocation();
   const isActive = useMemo(() => {
@@ -24,16 +26,19 @@ const CollapseMenu = ({
   const [isOpen, { toggle }] = useBoolean(isActive);
 
   return (
-    <div className={disabled ? 'disabled' : ''}>
+    <section className={`collapse  ${disabled ? 'disabled' : 'collapse-arrow'} ${isOpen ? 'collapse-open' : ''}`}>
       <button
         type="button"
-        className={`nav-item collapse-btn mb-0 ${isActive ? 'active' : ''}`}
+        className={`nav-item collapse-btn collapse-title ${isActive ? 'active' : ''}`}
         onClick={() => toggle()}
+        aria-controls={ariaControls}
+        aria-expanded={isOpen}
+        aria-disabled={disabled}
       >
         {button}
       </button>
-      <div className={`${isOpen ? '' : 'hidden'}`}>{children}</div>
-    </div>
+      <div className='collapse-content p-0'>{children}</div>
+    </section>
   );
 };
 
@@ -76,6 +81,7 @@ const Nav = memo(({ onClick }: NavProps) => {
             key={i}
             link={item.link}
             disabled={item.disabled}
+            ariaControls='submenu'
             button={
               <>
                 {item.prefix}

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -34,7 +34,7 @@ export default function Layout(): JSX.Element | null {
   return (
     <div id="main-wrapper" className="flex">
       <div id="sidebar-wrapper" className="flex flex-wrap z-50">
-        <div
+        <aside
           style={{
             ...(isPendulum ? null : { backgroundColor: '#1c1c1c' }),
           }}
@@ -62,7 +62,7 @@ export default function Layout(): JSX.Element | null {
             <NetworkId />
             <SocialAndTermLinks />
           </div>
-        </div>
+        </aside>
       </div>
       <section>
         <header>

--- a/src/components/Layout/links.tsx
+++ b/src/components/Layout/links.tsx
@@ -1,4 +1,3 @@
-import { ChevronRightIcon } from '@heroicons/react/20/solid';
 import { ComponentChildren } from 'preact';
 import { NavLinkProps } from 'react-router-dom';
 import DashboardIcon from '../../assets/dashboard';
@@ -32,8 +31,6 @@ export type LinkItem = BaseLinkItem & {
 };
 export type Links = (state: Partial<GlobalState>) => LinkItem[];
 
-const arrow = <ChevronRightIcon className="nav-arrow w-5 h-5" />;
-
 export const links: Links = ({ tenantName }) => [
   {
     link: './dashboard',
@@ -41,8 +38,7 @@ export const links: Links = ({ tenantName }) => [
     props: {
       className: ({ isActive } = {}) => (isActive ? 'active' : ''),
     },
-    prefix: <DashboardIcon />,
-    suffix: arrow,
+    prefix: <DashboardIcon />
   },
   {
     link: 'https://app.zenlink.pro/',
@@ -81,8 +77,7 @@ export const links: Links = ({ tenantName }) => [
     props: {
       className: ({ isActive } = {}) => (isActive ? 'active' : ''),
     },
-    prefix: <StakingIcon />,
-    suffix: arrow,
+    prefix: <StakingIcon />
   },
   {
     link: `https://${tenantName}.polkassembly.io/`,

--- a/src/components/Layout/styles.sass
+++ b/src/components/Layout/styles.sass
@@ -119,6 +119,7 @@ nav
       opacity: 1
 
   .collapse-btn
+    margin-top: 0
     margin-bottom: 0
 
   .disabled


### PR DESCRIPTION
Implement collapse styles for sidebar button with dropdown.
Remove Chevron from active sidebar button without dropdown.
Change semantics of sidebar to improve accessibility.

Closes #207 
