### PR TITLE
fix: add balance left for tx approval: staking

### DIFF
--- a/src/components/Form/Amount/index.tsx
+++ b/src/components/Form/Amount/index.tsx
@@ -13,6 +13,12 @@ export interface AmountProps {
 }
 
 const BALANCE_LEFT_FOR_TX_APPROVAL = 0.5;
+
+function calculateMaxAmount(max: number) {
+  const maxAmount = roundNumber(max - BALANCE_LEFT_FOR_TX_APPROVAL);
+  return Math.max(0, maxAmount);
+}
+
 const Amount = ({ className, register, max, setValue, error }: AmountProps): JSX.Element | null => {
   return (
     <>
@@ -46,7 +52,7 @@ const Amount = ({ className, register, max, setValue, error }: AmountProps): JSX
             </button>
             <button
               className="text-accent-content underline hover:opacity-70 mx-1 font-semibold"
-              onClick={() => setValue(roundNumber(Number(max) - BALANCE_LEFT_FOR_TX_APPROVAL))}
+              onClick={() => setValue(calculateMaxAmount(Number(max)))}
               type="button"
             >
               MAX

--- a/src/components/Form/Amount/index.tsx
+++ b/src/components/Form/Amount/index.tsx
@@ -13,7 +13,6 @@ export interface AmountProps {
 }
 
 const BALANCE_LEFT_FOR_TX_APPROVAL = 0.5;
-
 const Amount = ({ className, register, max, setValue, error }: AmountProps): JSX.Element | null => {
   return (
     <>

--- a/src/components/Form/Amount/index.tsx
+++ b/src/components/Form/Amount/index.tsx
@@ -12,7 +12,9 @@ export interface AmountProps {
   error?: string;
 }
 
-const Amount = ({ className, register, max, setValue, assetSuffix, error }: AmountProps): JSX.Element | null => {
+const BALANCE_LEFT_FOR_TX_APPROVAL = 0.5;
+
+const Amount = ({ className, register, max, setValue, error }: AmountProps): JSX.Element | null => {
   return (
     <>
       <div
@@ -45,7 +47,7 @@ const Amount = ({ className, register, max, setValue, assetSuffix, error }: Amou
             </button>
             <button
               className="text-accent-content underline hover:opacity-70 mx-1 font-semibold"
-              onClick={() => setValue(roundNumber(Number(max)))}
+              onClick={() => setValue(roundNumber(Number(max) - BALANCE_LEFT_FOR_TX_APPROVAL))}
               type="button"
             >
               MAX


### PR DESCRIPTION
### What:

When user decides to stakes with "MAX" button, the entire PEN balance is considered in that transaction leaving no tokens for the user to execute the transaction i.e no gas fees to execute the transaction

### How:

Add BALANCE_LEFT_FOR_TX_APPROVAL constant variable.

Closes: #296 

