### PR TITLE
fix: add Buffer polyfill to window global object

### DIFF
--- a/src/helpers/stellar.ts
+++ b/src/helpers/stellar.ts
@@ -1,6 +1,10 @@
 import { Asset, Keypair, StrKey } from 'stellar-sdk';
 import { Buffer } from 'buffer';
 
+// Applying this assignment to the global object here - because Buffer is used only in this file. If Buffer is to be used in several places - it should be added to the global object in the entry file of the application.
+// Ref: https://github.com/pendulum-chain/portal/issues/344
+window.Buffer = Buffer;
+
 export const StellarPublicKeyPattern = /^G[A-Z0-9]{55}$/;
 
 export const isPublicKey = (str: string) => Boolean(str.match(StellarPublicKeyPattern));


### PR DESCRIPTION
### What:
In the Spacewalk, experiencing the error:
Error converting currency to stellar asset ReferenceError: Buffer is not defined

### How:

Fixed by implementing `window.Buffer = Buffer;`

Closes: #345 


