### PR TITLE
chore: Configure semantic-release to add release commit on feature branch when PR is closed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   semantic-release:
     name: Running semantic-release on PR
+    if: ${{ github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,13 @@
-name: semantic release
+name: semantic-release
 on:
-  pull_request:
+  push:
     branches: [staging]
-    types: [closed]
 
   workflow_dispatch:
 
 jobs:
   semantic-release:
-    name: Running semantic-release on PR
-    if: ${{ github.event.pull_request.merged == true }}
+    name: Running semantic-release
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -21,9 +19,9 @@ jobs:
       - name: 🛒 Checkout code
         uses: actions/checkout@v3
         with:
+          persist-credentials: false
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: 💿 Setup Nodejs
         uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,14 @@
-name: release
+name: semantic release
 on:
-  push:
-    branches: [staging, develop]
+  pull_request:
+    branches: [staging]
+    types: [closed]
 
   workflow_dispatch:
 
 jobs:
   semantic-release:
-    name: Running push
-    if: "!contains(toJSON(github.event.commits.*.message), 'chore(release):')"
+    name: Running semantic-release on PR
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: 💿 Setup Nodejs
         uses: actions/setup-node@v3
@@ -54,4 +55,3 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-  branches: ['staging', 'develop'],
+  branches: ['staging'],
   plugins: [
     [
       '@semantic-release/commit-analyzer',
@@ -27,5 +27,6 @@ module.exports = {
         assets: ['package.json', 'CHANGELOG.md'],
       },
     ],
+    '@semantic-release/github'
   ],
 };


### PR DESCRIPTION
### What:

Configure semantic-release to add release commit on feature branch when PR is closed

### How:

✅ Update Github Actions Workflow
✅ Update semantic-release config to include creation of Github Release

### Comments:

The failures were due to Semantic-Release attempting to push both the "release tag" and the "release commit" directly to a protected branch.