### PR TITLE
chore: change workflows to point on the main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: ci
 on:
   pull_request:
-    branches: [main, staging, develop]
+    branches: [main]
 
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: semantic-release
 on:
   push:
-    branches: [staging]
+    branches: [main]
 
   workflow_dispatch:
 

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-  branches: ['staging'],
+  branches: ['main'],
   plugins: [
     [
       '@semantic-release/commit-analyzer',


### PR DESCRIPTION
Change Github Actions to point on the `main` as we removed the `staging`