### PR TITLE
Close the older pop-up when successfully staked

### DIFF
--- a/src/pages/collators/dialogs/ExecuteDelegationDialogs.tsx
+++ b/src/pages/collators/dialogs/ExecuteDelegationDialogs.tsx
@@ -40,6 +40,12 @@ function ExecuteDelegationDialogs(props: ExecuteDelegationDialogsProps) {
   const [confirmationDialogVisible, setConfirmationDialogVisible] = useState<boolean>(false);
   const [unstakingAll, setUnstakingAll] = useState<boolean>(false);
 
+  const resetState = () => {
+    setDelegationAmount(undefined);
+    setSubmissionPending(false);
+    setUnstakingAll(false);
+  };
+
   const totalFee = useMemo(() => {
     switch (mode) {
       case 'unstaking':
@@ -117,7 +123,7 @@ function ExecuteDelegationDialogs(props: ExecuteDelegationDialogsProps) {
           setDelegationAmount(undefined);
           onClose();
         }}
-        visible={Boolean(selectedCandidate && delegationAmount)}
+        visible={!confirmationDialogVisible && Boolean(selectedCandidate && delegationAmount)}
       />
       <DelegationSuccessfulDialog
         visible={confirmationDialogVisible}
@@ -125,10 +131,12 @@ function ExecuteDelegationDialogs(props: ExecuteDelegationDialogsProps) {
         onClose={() => {
           setConfirmationDialogVisible(false);
           onClose();
+          resetState();
         }}
         onConfirm={() => {
           setConfirmationDialogVisible(false);
           onClose();
+          resetState();
         }}
       />
     </>


### PR DESCRIPTION
### What:

When a user is able to successfully stake, portal shows a pop-up about the confirmation about the stake but the earlier pop-up for adding the inputs and staking does get closed.

### How:

<!-- How were these changes implemented? -->

### Comments:

Closes: #377 
