### PR TITLE
Screen freezes when manually selecting vault for EURC on Spacewalk

### DIFF
--- a/src/components/Selector/VaultSelector.tsx
+++ b/src/components/Selector/VaultSelector.tsx
@@ -43,7 +43,7 @@ function VaultSelector(props: VaultSelectorProps): JSX.Element {
               </span>
               {showMaxTokensFor && (
                 <span className="content-end">
-                  {nativeToDecimal(vault[showMaxTokensFor]?.toString() || '0').toFixed(2)}{' '}
+                  {nativeToDecimal((vault[showMaxTokensFor] as unknown as { amount: string }).amount || '0').toFixed(2)}
                   {convertCurrencyToStellarAsset(vault.id.currencies.wrapped)?.getCode()}
                 </span>
               )}


### PR DESCRIPTION
### What:

Which user interface was the bug observed on?
Portal Spacewalk Bridge settings wheel crashes the interaction

What steps did you take?
Portal
Bridge
Change Asset to EURC
Settings wheel
Check manually select vault
UI freezes nothing else possible to select click or get out of the menu

### How:

The vault object has nested `amount` property that stores the required value. We passed the object `{ amount: "number-value"}` instead of a valid numeric value to the Big constructor.

Closes: #445 
