### PR TITLE
Add prop for showing security deposit

### DIFF
--- a/src/pages/bridge/FeeBox.tsx
+++ b/src/pages/bridge/FeeBox.tsx
@@ -6,17 +6,18 @@ import { useFeePallet } from '../../hooks/spacewalk/useFeePallet';
 import { nativeStellarToDecimal, nativeToDecimal } from '../../shared/parseNumbers/metric';
 
 interface FeeBoxProps {
-  bridgedAsset?: Asset;
   // The amount of the bridged asset denoted in the smallest unit of the asset
   amountNative: Big;
+  bridgedAsset?: Asset;
   extrinsic?: SubmittableExtrinsic;
-  network: string;
-  wrappedCurrencySuffix?: string;
   nativeCurrency: string;
+  network: string;
+  showSecurityDeposit?: boolean;
+  wrappedCurrencySuffix?: string;
 }
 
 export function FeeBox(props: FeeBoxProps): JSX.Element {
-  const { bridgedAsset, extrinsic, network, wrappedCurrencySuffix, nativeCurrency } = props;
+  const { bridgedAsset, extrinsic, network, wrappedCurrencySuffix, nativeCurrency, showSecurityDeposit } = props;
   const amount = props.amountNative;
   const wrappedCurrencyName = bridgedAsset ? bridgedAsset.getCode() + (wrappedCurrencySuffix || '') : '';
   const { getFees, getTransactionFee } = useFeePallet();
@@ -83,12 +84,14 @@ export function FeeBox(props: FeeBoxProps): JSX.Element {
             {bridgeFee.toString()} {bridgedAsset?.getCode()}
           </span>
         </div>
-        <div className="flex justify-between mt-2">
-          <span>Security Deposit</span>
-          <span className="text-right">
-            {griefingCollateral.toString()} {nativeCurrency}
-          </span>
-        </div>
+        {showSecurityDeposit && (
+          <div className="flex justify-between mt-2">
+            <span>Security Deposit</span>
+            <span className="text-right">
+              {griefingCollateral.toString()} {nativeCurrency}
+            </span>
+          </div>
+        )}
         <div className="flex justify-between mt-2">
           <span>Transaction Fee</span>
           <span className="text-right">

--- a/src/pages/bridge/Issue/index.tsx
+++ b/src/pages/bridge/Issue/index.tsx
@@ -86,7 +86,7 @@ function Issue(props: IssueProps): JSX.Element {
     () => (
       <ul className="list-disc pl-4">
         <li>Bridge Fee: Currently zero fee, transitioning to 0.1% per transaction soon.</li>
-        <li>Security deposit: 0.5% of the transaction amount locked, returned after successful issue/redeem. </li>
+        <li>Security deposit: 0.5% of the transaction amount locked, returned after successful issue/redeem.</li>
         <li>
           Total issuable amount (in USD): {tenantName === TenantName.Pendulum ? 50000 : 20000} USD. Join our vault
           operator program, more
@@ -218,9 +218,10 @@ function Issue(props: IssueProps): JSX.Element {
             amountNative={amountNative}
             bridgedAsset={selectedAsset}
             extrinsic={requestIssueExtrinsic}
-            network={network}
-            wrappedCurrencySuffix={wrappedCurrencySuffix}
             nativeCurrency={nativeCurrency}
+            network={network}
+            showSecurityDeposit
+            wrappedCurrencySuffix={wrappedCurrencySuffix}
           />
           {walletAccount ? (
             <Button


### PR DESCRIPTION
### What:

Don't show security deposit for redeem requests.

### How:

Adds an extra prop to show/hide the security deposit.

Closes #438.
