### PR TITLE
Trigger form validation when selected asset changes

### DIFF
--- a/src/pages/bridge/Issue/index.tsx
+++ b/src/pages/bridge/Issue/index.tsx
@@ -25,6 +25,7 @@ import { prioritizeXLMAsset } from '../helpers';
 import { ConfirmationDialog } from './ConfirmationDialog';
 import Disclaimer from './Disclaimer';
 import { getIssueValidationSchema } from './IssueValidationSchema';
+import { useEffect } from 'preact/compat';
 
 interface IssueProps {
   network: string;
@@ -86,7 +87,7 @@ function Issue(props: IssueProps): JSX.Element {
     () => (
       <ul className="list-disc pl-4">
         <li>Bridge Fee: Currently zero fee, transitioning to 0.1% per transaction soon.</li>
-        <li>Security deposit: 0.5% of the transaction amount locked, returned after successful issue/redeem. </li>
+        <li>Security deposit: 0.5% of the transaction amount locked, returned after successful issue/redeem.</li>
         <li>
           Total issuable amount (in USD): {tenantName === TenantName.Pendulum ? 50000 : 20000} USD. Join our vault
           operator program, more
@@ -173,10 +174,15 @@ function Issue(props: IssueProps): JSX.Element {
     [api, getIssueRequest, requestIssueExtrinsic, selectedVault, walletAccount],
   );
 
-  useMemo(() => {
+  useEffect(() => {
     setValue('securityDeposit', amount * issueGriefingCollateral.toNumber());
     trigger('securityDeposit');
   }, [amount, issueGriefingCollateral, setValue, trigger]);
+
+  useEffect(() => {
+    // Trigger form validation when the selected asset changes
+    trigger();
+  }, [trigger, selectedAsset, maxIssuable]);
 
   return (
     <div className="flex items-center justify-center h-full space-walk py-4">


### PR DESCRIPTION
### What:

Fixes an issue where the error message stays after changing the selected assets.

### How:

Triggers the validation on all form fields when the selected asset or the max issuable amount changes.

### Comments:

Closes #441.