### PR TITLE
fix lottie animation stops playing onclick

### DIFF
--- a/src/components/Layout/NavCollapseButtonContent.tsx
+++ b/src/components/Layout/NavCollapseButtonContent.tsx
@@ -10,13 +10,23 @@ interface NavButtonContentProps {
 export const NavCollapseButtonContent: React.FC<NavButtonContentProps> = ({ item, isPlaying }) => (
   <>
     {isLottieOptions(item.prefix) ? (
-      <Lottie options={item.prefix.lottieOptions} isStopped={!isPlaying} {...item.prefix.componentOptions} />
+      <Lottie
+        options={item.prefix.lottieOptions}
+        isStopped={!isPlaying}
+        isClickToPauseDisabled={true}
+        {...item.prefix.componentOptions}
+      />
     ) : (
       item.prefix
     )}
     {isLottieOptions(item.title) ? (
       <span>
-        <Lottie options={item.title.lottieOptions} isStopped={!isPlaying} {...item.title.componentOptions} />
+        <Lottie
+          options={item.title.lottieOptions}
+          isStopped={!isPlaying}
+          isClickToPauseDisabled={true}
+          {...item.title.componentOptions}
+        />
       </span>
     ) : (
       <span>{item.title}</span>

--- a/src/components/Layout/links.tsx
+++ b/src/components/Layout/links.tsx
@@ -21,8 +21,17 @@ export type LottieOptions = { lottieOptions: Options } & {
   componentOptions: { height?: number; width?: number; style?: Record<string, string | number> };
 };
 
-export function isLottieOptions(obj: any): obj is LottieOptions {
-  return obj && typeof obj === 'object' && 'lottieOptions' in obj && 'animationData' in obj['lottieOptions'];
+export function isLottieOptions(obj: unknown): obj is LottieOptions {
+  if (typeof obj === 'object' && obj !== null) {
+    const possibleLottieOptions = obj as { lottieOptions?: unknown };
+    return (
+      'lottieOptions' in possibleLottieOptions &&
+      typeof possibleLottieOptions.lottieOptions === 'object' &&
+      possibleLottieOptions.lottieOptions !== null &&
+      'animationData' in possibleLottieOptions.lottieOptions
+    );
+  }
+  return false;
 }
 
 export type TitleOptions = LottieOptions | ComponentChildren;

--- a/src/components/Layout/spacewalkAnimation.ts
+++ b/src/components/Layout/spacewalkAnimation.ts
@@ -6,40 +6,34 @@ import AmpeLottieInterpolation from '../../assets/spacewalk/AMPE_StellarBridgeTo
 import PenLottieText from '../../assets/spacewalk/PEN_StellarBridgeToSpacewalk_Text.json';
 import PenLottieInterpolation from '../../assets/spacewalk/PEN_StellarBridgeToSpacewalk_Interpolation.json';
 
-const SPACEWALK_TEXT_HEIGHT = 20;
-const SPACEWALK_TEXT_WIDTH = 96;
-
-export const getSpacewalkText = (tenantName: TenantName | undefined): LottieOptions => ({
+const createLottieOptions = (animationData: unknown, height: number, width: number): LottieOptions => ({
   lottieOptions: {
     loop: false,
     autoplay: false,
-    animationData: tenantName === TenantName.Pendulum ? PenLottieText : AmpeLottieText,
+    animationData,
     rendererSettings: {
       preserveAspectRatio: 'xMidYMid slice',
     },
   },
   componentOptions: {
-    height: SPACEWALK_TEXT_HEIGHT,
-    width: SPACEWALK_TEXT_WIDTH,
+    height,
+    width,
     style: { margin: 0 },
   },
 });
+
+const SPACEWALK_TEXT_HEIGHT = 20;
+const SPACEWALK_TEXT_WIDTH = 96;
+
+export const getSpacewalkText = (tenantName: TenantName | undefined): LottieOptions => {
+  const animationData = tenantName === TenantName.Pendulum ? PenLottieText : AmpeLottieText;
+  return createLottieOptions(animationData, SPACEWALK_TEXT_HEIGHT, SPACEWALK_TEXT_WIDTH);
+};
 
 const SPACEWALK_ICON_HEIGHT = 32;
 const SPACEWALK_ICON_WIDTH = 32;
 
-export const getSpacewalkInterpolation = (tenantName: TenantName | undefined): LottieOptions => ({
-  lottieOptions: {
-    loop: false,
-    autoplay: false,
-    animationData: tenantName === TenantName.Pendulum ? PenLottieInterpolation : AmpeLottieInterpolation,
-    rendererSettings: {
-      preserveAspectRatio: 'xMidYMid slice',
-    },
-  },
-  componentOptions: {
-    height: SPACEWALK_ICON_HEIGHT,
-    width: SPACEWALK_ICON_WIDTH,
-    style: { margin: 0 },
-  },
-});
+export const getSpacewalkInterpolation = (tenantName: TenantName | undefined): LottieOptions => {
+  const animationData = tenantName === TenantName.Pendulum ? PenLottieInterpolation : AmpeLottieInterpolation;
+  return createLottieOptions(animationData, SPACEWALK_ICON_HEIGHT, SPACEWALK_ICON_WIDTH);
+};


### PR DESCRIPTION
### What:

When you hover your cursor over “Stellar Bridge” in the navigation, the Lottie animation starts playing, however, if you click on it while the animation is playing, the animation stops and cannot continue.

### How:

✅ Add `isClickToPauseDisabled={true}` to the Lottie component
✅ Add `createLottieOptions` function to make the code less repetitive

⚠️ Note
In the console this Lottie error appears:
`Failed prop type: Invalid prop 'style' of type 'object' supplied to 'Lottie2', expected 'string'`
The error appears since the day we implemented it, unfortunately the developer of the react-lottie library implemented the types incorrectly and the styles of the `<Lottie>` component cannot be implemented without this error