### PR TITLE
Fix parsing of amounts in vault selector

### DIFF
--- a/src/components/Selector/VaultSelector.tsx
+++ b/src/components/Selector/VaultSelector.tsx
@@ -1,5 +1,6 @@
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 import { Button, Dropdown } from 'react-daisyui';
+import { BridgeDirection } from '../../pages/spacewalk/bridge';
 import { convertCurrencyToStellarAsset } from '../../helpers/spacewalk';
 import { ExtendedRegistryVault } from '../../hooks/spacewalk/useVaultRegistryPallet';
 import { nativeToDecimal } from '../../shared/parseNumbers/metric';
@@ -8,7 +9,7 @@ import { PublicKey } from '../PublicKey';
 interface VaultSelectorProps {
   vaults: ExtendedRegistryVault[];
   selectedVault?: ExtendedRegistryVault;
-  bridgeDirection?: 'issue' | 'redeem';
+  bridgeDirection?: BridgeDirection;
   onChange: (vault: ExtendedRegistryVault) => void;
 }
 

--- a/src/components/Selector/VaultSelector.tsx
+++ b/src/components/Selector/VaultSelector.tsx
@@ -8,12 +8,27 @@ import { PublicKey } from '../PublicKey';
 interface VaultSelectorProps {
   vaults: ExtendedRegistryVault[];
   selectedVault?: ExtendedRegistryVault;
-  showMaxTokensFor?: 'issuableTokens' | 'redeemableTokens';
+  bridgeDirection?: 'issue' | 'redeem';
   onChange: (vault: ExtendedRegistryVault) => void;
 }
 
+function getMaxTokensForVault(vault: ExtendedRegistryVault, type: 'issue' | 'redeem') {
+  const maxTokens = type === 'issue' ? vault.issuableTokens : vault.redeemableTokens;
+  if (!maxTokens) return '0';
+
+  try {
+    const balance: { amount: string } = maxTokens.toJSON();
+
+    return nativeToDecimal(balance.amount.toString()).toFixed(2);
+  } catch (error) {
+    console.error('Error parsing max tokens', error);
+    return '0';
+  }
+}
+
 function VaultSelector(props: VaultSelectorProps): JSX.Element {
-  const { vaults, selectedVault, showMaxTokensFor, onChange } = props;
+  const { vaults, selectedVault, bridgeDirection, onChange } = props;
+
   return (
     <div className="dropdown w-full mt-3">
       <Button
@@ -35,15 +50,15 @@ function VaultSelector(props: VaultSelectorProps): JSX.Element {
               }
               onChange(vault);
             }}
-            className="w-full rounded-md"
+            className="w-full rounded-md flex"
           >
             <span className="w-full flex place-content-between">
               <span className="flex">
                 <PublicKey publicKey={vault.id.accountId.toString()} variant="short" />
               </span>
-              {showMaxTokensFor && (
+              {bridgeDirection && (
                 <span className="content-end">
-                  {nativeToDecimal((vault[showMaxTokensFor] as unknown as { amount: string }).amount || '0').toFixed(2)}
+                  {getMaxTokensForVault(vault, bridgeDirection)}{' '}
                   {convertCurrencyToStellarAsset(vault.id.currencies.wrapped)?.getCode()}
                 </span>
               )}

--- a/src/pages/spacewalk/bridge/Issue/SettingsDialog.tsx
+++ b/src/pages/spacewalk/bridge/Issue/SettingsDialog.tsx
@@ -7,9 +7,10 @@ import { useMemo } from 'preact/hooks';
 interface Props {
   onClose: () => void;
   visible: boolean;
+  bridgeDirection: 'issue' | 'redeem';
 }
 
-export function SettingsDialog({ visible, onClose }: Props) {
+export function SettingsDialog({ bridgeDirection, visible, onClose }: Props) {
   const { manualVaultSelection, vaultsForCurrency, setManualVaultSelection, selectedVault, setSelectedVault } =
     useBridgeSettings();
 
@@ -37,7 +38,7 @@ export function SettingsDialog({ visible, onClose }: Props) {
               vaults={vaultsForCurrency}
               onChange={setSelectedVault}
               selectedVault={selectedVault}
-              showMaxTokensFor="issuableTokens"
+              bridgeDirection={bridgeDirection}
             />
           </div>
         )}

--- a/src/pages/spacewalk/bridge/Issue/SettingsDialog.tsx
+++ b/src/pages/spacewalk/bridge/Issue/SettingsDialog.tsx
@@ -1,13 +1,14 @@
 import { Button, Checkbox } from 'react-daisyui';
+import { useMemo } from 'preact/hooks';
 import VaultSelector from '../../../../components/Selector/VaultSelector';
 import useBridgeSettings from '../../../../hooks/spacewalk/useBridgeSettings';
 import { Dialog } from '../../../staking/dialogs/Dialog';
-import { useMemo } from 'preact/hooks';
+import { BridgeDirection } from '../index';
 
 interface Props {
   onClose: () => void;
   visible: boolean;
-  bridgeDirection: 'issue' | 'redeem';
+  bridgeDirection: BridgeDirection;
 }
 
 export function SettingsDialog({ bridgeDirection, visible, onClose }: Props) {

--- a/src/pages/spacewalk/bridge/index.tsx
+++ b/src/pages/spacewalk/bridge/index.tsx
@@ -52,10 +52,16 @@ function Bridge(): JSX.Element | null {
     onClick: () => setTabValue(index),
   });
 
+  const bridgeDirection = tabValue === BridgeTabs.Issue ? 'issue' : 'redeem';
+
   return chain ? (
     <BridgeContext.Provider value={{ selectedAsset, setSelectedAsset }}>
       <div className="h-full flex items-center justify-center mt-4">
-        <SettingsDialog visible={settingsVisible} onClose={() => setSettingsVisible(false)} />
+        <SettingsDialog
+          bridgeDirection={bridgeDirection}
+          visible={settingsVisible}
+          onClose={() => setSettingsVisible(false)}
+        />
         <Card className="bridge-card bg-base-200 min-h-500 w-full max-w-[520px] rounded-lg">
           <div className="flex justify-between px-5 mt-5">
             <Tabs className="flex w-5/6 flex-grow justify-center tabs-boxed">

--- a/src/pages/spacewalk/bridge/index.tsx
+++ b/src/pages/spacewalk/bridge/index.tsx
@@ -19,6 +19,11 @@ enum BridgeTabs {
   Redeem = 1,
 }
 
+export enum BridgeDirection {
+  Issue = 'issue',
+  Redeem = 'redeem',
+}
+
 interface BridgeContextValue {
   selectedAsset?: Asset;
   setSelectedAsset: Dispatch<StateUpdater<Asset | undefined>>;
@@ -52,7 +57,7 @@ function Bridge(): JSX.Element | null {
     onClick: () => setTabValue(index),
   });
 
-  const bridgeDirection = tabValue === BridgeTabs.Issue ? 'issue' : 'redeem';
+  const bridgeDirection = tabValue === BridgeTabs.Issue ? BridgeDirection.Issue : BridgeDirection.Redeem;
 
   return chain ? (
     <BridgeContext.Provider value={{ selectedAsset, setSelectedAsset }}>


### PR DESCRIPTION
- [x] Fix alignment of amount text in dropdown item of manual vault selection (there was no space between vault ID and amount)
- [x] Make parsing more resilient ie catch errors. 
- [x] Fix bug where always the issuable amount was used, even on the manual vault selection for redeeming

The problem that 'broke' the feature in the first place is that the RPC call for `getVaultsWithIssuableTokens()` for some reason returns an empty array on Pendulum at the moment.

Closes #508.