### PR TITLE
Fix missing slash in redirect

### DIFF
--- a/src/pages/spacewalk/bridge/Issue/index.tsx
+++ b/src/pages/spacewalk/bridge/Issue/index.tsx
@@ -201,7 +201,7 @@ function Issue(props: IssueProps): JSX.Element {
         onClose={() => setConfirmationDialogVisible(false)}
         onConfirm={() => {
           setConfirmationDialogVisible(false);
-          navigateTo(`/${tenantName}${PAGES_PATHS.TRANSACTIONS}`);
+          navigateTo(`/${tenantName}/${PAGES_PATHS.TRANSACTIONS}`);
         }}
       />
       <div className="w-full">

--- a/src/pages/spacewalk/bridge/Redeem/ConfirmationDialog.tsx
+++ b/src/pages/spacewalk/bridge/Redeem/ConfirmationDialog.tsx
@@ -58,7 +58,7 @@ export function ConfirmationDialog(props: ConfirmationDialogProps): JSX.Element 
       <Button
         color="primary"
         onClick={() => {
-          navigateTo(`/${tenantName}${PAGES_PATHS.TRANSACTIONS}`);
+          navigateTo(`/${tenantName}/${PAGES_PATHS.TRANSACTIONS}`);
         }}
       >
         View Progress


### PR DESCRIPTION
Adds the missing slash to the URL when redirecting after creating a new Spacewalk request.

Closes #509.