### PR TITLE
improve code readability

### DIFF
--- a/src/components/Selector/AssetSelector/helpers.ts
+++ b/src/components/Selector/AssetSelector/helpers.ts
@@ -26,12 +26,12 @@ function areOrmlAssets(obj?: BlockchainAsset[]): obj is OrmlTraitsAssetRegistryA
   return Array.isArray(obj) && obj.every(isOrmlAsset);
 }
 
-export function getAssetIcon(asset?: BlockchainAsset): string {
+function getAssetIcon(asset?: BlockchainAsset): string {
   if (!asset) return '';
   return isStellarAsset(asset) ? getIcon(asset?.code, asset?.issuer) : getIcon(asset.metadata.symbol);
 }
 
-export function getAssetName(asset?: BlockchainAsset): string {
+function getAssetName(asset?: BlockchainAsset): string {
   if (!asset) return '';
   return isStellarAsset(asset) ? asset?.code : asset.metadata.symbol;
 }
@@ -102,6 +102,13 @@ export function generateAssetSelectorItem(
   return { formattedAssets: [], selectedAssetItem: undefined };
 }
 
+export interface AssetItem {
+  displayName: string;
+  id: string;
+  name: string;
+  icon?: string;
+}
+
 function generateAssetItems(
   assets: BlockchainAsset[],
   formatAssets: (asset: BlockchainAsset) => string,
@@ -112,6 +119,7 @@ function generateAssetItems(
     displayName: formatAssets(asset),
     id: getId(asset),
     icon: getAssetIcon(asset),
+    name: getAssetName(asset),
   }));
 
   const selectedAssetItem = selectedAsset
@@ -119,6 +127,7 @@ function generateAssetItems(
         displayName: formatAssets(selectedAsset),
         id: getId(selectedAsset),
         icon: getAssetIcon(selectedAsset),
+        name: getAssetName(selectedAsset),
       }
     : undefined;
 

--- a/src/components/Selector/AssetSelector/index.tsx
+++ b/src/components/Selector/AssetSelector/index.tsx
@@ -8,10 +8,9 @@ import {
   AssetSelectorOnChange,
   isStellarAsset,
   generateAssetSelectorItem,
-  getAssetIcon,
   onOrmlAssetOnChange,
   onStellarAssetOnChange,
-  getAssetName,
+  AssetItem,
 } from './helpers';
 
 interface AssetSelectorProps {
@@ -27,15 +26,8 @@ interface AssetSelectorProps {
 function AssetSelector(props: AssetSelectorProps): JSX.Element {
   const { assets, selectedAsset, assetPrefix, assetSuffix, disabled = false } = props;
 
-  const [items, setItems] = useState<{ displayName: string; id: string; icon?: string }[]>([]);
-  const [selectedItem, setSelectedItem] = useState<
-    | {
-        displayName: string;
-        id: string;
-        icon?: string;
-      }
-    | undefined
-  >(undefined);
+  const [items, setItems] = useState<AssetItem[]>([]);
+  const [selectedItem, setSelectedItem] = useState<AssetItem | undefined>(undefined);
 
   useEffect(() => {
     const { formattedAssets, selectedAssetItem } = generateAssetSelectorItem(
@@ -67,7 +59,7 @@ function AssetSelector(props: AssetSelectorProps): JSX.Element {
         type="button"
       >
         <span className="rounded-full bg-[rgba(0,0,0,0.15)] h-full mr-1 ">
-          <img src={selectedItem?.icon} alt={getAssetName(selectedAsset)} className="h-full w-auto " />
+          <img src={selectedItem?.icon} alt={selectedItem?.name} className="h-full w-auto " />
         </span>
         <strong className="font-bold">{selectedItem?.displayName}</strong>
         {items.length > 1 ? <ChevronDownIcon className="w-4 h-4 inline ml-px" /> : <div className="px-1" />}

--- a/src/components/Selector/DropdownSelector.tsx
+++ b/src/components/Selector/DropdownSelector.tsx
@@ -1,4 +1,5 @@
 import { Dropdown } from 'react-daisyui';
+import { AssetItem } from './AssetSelector/helpers';
 
 interface Props<T> {
   items: T[];
@@ -7,7 +8,7 @@ interface Props<T> {
   children: JSX.Element;
 }
 
-function DropdownSelector<T extends { id: unknown; displayName: string; icon?: string }>(props: Props<T>) {
+function DropdownSelector<T extends AssetItem>(props: Props<T>) {
   const { items, onChange, children } = props;
   return (
     <div className="flex flex-grow">
@@ -25,7 +26,7 @@ function DropdownSelector<T extends { id: unknown; displayName: string; icon?: s
                 onChange(item);
               }}
             >
-              {item.icon && <img src={item.icon} className="w-6" alt={item.displayName + ' icon'} />}
+              {item.icon && <img src={item.icon} className="w-6" alt={item?.name} />}
               {item.displayName}
             </Dropdown.Item>
           ))}

--- a/src/shared/AssetIcons.tsx
+++ b/src/shared/AssetIcons.tsx
@@ -18,6 +18,7 @@ import DefaultIcon from '../assets/coins/placeholder.png';
 // The public key of Mykobo's EURC issuer account
 const MYKOBO_ISSUER = 'GAQRF3UGHBT6JYQZ7YSUYCIYWAF4T2SAA5237Q5LIQYJOHHFAWDXZ7NM';
 
+// Maps all supported Stellar assets to icons. The EURC tokens are handled separately in `getAssetIcon()`
 const stellarAssets = [
   { code: 'AUDD', icon: AUDD },
   { code: 'BRL', icon: BRL },
@@ -36,10 +37,16 @@ const polkadotAssets = [
   { code: 'GLMR', icon: GLMR },
 ];
 
-const getAssetIcon = (assetCode: string, assetIssuer: string, assets: { code: string; icon: string }[]) => {
+const handleSpecialAsset = (assetCode: string, assetIssuer: string) => {
+  // The EURC tokens are handled separately because they can be issued by multiple issuers
   if (assetCode.includes('EURC')) {
     return assetIssuer === MYKOBO_ISSUER ? mEURC : cEURC;
   }
+};
+
+const getAssetIcon = (assetCode: string, assetIssuer: string, assets: { code: string; icon: string }[]) => {
+  const specialAsset = handleSpecialAsset(assetCode, assetIssuer);
+  if (specialAsset) return specialAsset;
 
   const asset = assets.find((asset) => assetCode.includes(asset.code));
 

--- a/src/shared/AssetIcons.tsx
+++ b/src/shared/AssetIcons.tsx
@@ -18,52 +18,47 @@ import DefaultIcon from '../assets/coins/placeholder.png';
 // The public key of Mykobo's EURC issuer account
 const MYKOBO_ISSUER = 'GAQRF3UGHBT6JYQZ7YSUYCIYWAF4T2SAA5237Q5LIQYJOHHFAWDXZ7NM';
 
-const getStellarAssetIcon = (assetCode: string, assetIssuer: string) => {
-  if (assetCode.includes('AUDD')) {
-    return AUDD;
-  } else if (assetCode.includes('BRL')) {
-    return BRL;
-  } else if (assetCode.includes('EURC')) {
-    if (assetIssuer === MYKOBO_ISSUER) {
-      return mEURC;
-    } else {
-      // Use the Circle EURC icon for all other EURC issuers
-      return cEURC;
-    }
-  } else if (assetCode.includes('NGNC')) {
-    return NGNC;
-  } else if (assetCode.includes('TZS')) {
-    return TZS;
-  } else if (assetCode.includes('USDC')) {
-    return USDC;
-  } else if (assetCode.includes('XLM')) {
-    return XLM;
+const stellarAssets = [
+  { code: 'AUDD', icon: AUDD },
+  { code: 'BRL', icon: BRL },
+  { code: 'NGNC', icon: NGNC },
+  { code: 'TZS', icon: TZS },
+  { code: 'USDC', icon: USDC },
+  { code: 'XLM', icon: XLM },
+];
+
+const polkadotAssets = [
+  { code: 'PEN', icon: PEN },
+  { code: 'DOT', icon: DOT },
+  { code: 'AMPE', icon: AMPE },
+  { code: 'KSM', icon: KSM },
+  { code: 'USDT', icon: USDT },
+  { code: 'GLMR', icon: GLMR },
+];
+
+const getAssetIcon = (assetCode: string, assetIssuer: string, assets: { code: string; icon: string }[]) => {
+  if (assetCode.includes('EURC')) {
+    return assetIssuer === MYKOBO_ISSUER ? mEURC : cEURC;
   }
 
-  return undefined;
+  const asset = assets.find((asset) => assetCode.includes(asset.code));
+
+  return asset?.icon || undefined;
+};
+
+const getStellarAssetIcon = (assetCode: string, assetIssuer?: string) => {
+  return getAssetIcon(assetCode, assetIssuer || '', stellarAssets);
 };
 
 const getPolkadotAssetIcon = (assetCode: string) => {
-  if (assetCode.includes('PEN')) {
-    return PEN;
-  } else if (assetCode.includes('DOT')) {
-    return DOT;
-  } else if (assetCode.includes('AMPE')) {
-    return AMPE;
-  } else if (assetCode.includes('KSM')) {
-    return KSM;
-  } else if (assetCode.includes('USDT')) {
-    return USDT;
-  } else if (assetCode.includes('GLMR')) {
-    return GLMR;
-  }
-
-  return undefined;
+  return getAssetIcon(assetCode, '', polkadotAssets);
 };
 
 export function getIcon(token: string | undefined, issuer?: string, defaultIcon = DefaultIcon) {
-  const polkadotIcon = getPolkadotAssetIcon(token || '');
-  const stellarIcon = getStellarAssetIcon(token || '', issuer || '');
+  if (!token) return defaultIcon;
+
+  const polkadotIcon = getPolkadotAssetIcon(token);
+  const stellarIcon = getStellarAssetIcon(token, issuer);
 
   return polkadotIcon || stellarIcon || defaultIcon;
 }


### PR DESCRIPTION
✅ Unify AssetItem object (now it uses AssetItem interface, it already has name - so all of the AssetItem helper functions are private, and all the needed properties are already in the object)

✅ Change the structure of AssetIcons to avoid repetition
