### PR TITLE
Hide Mykobo EURC when issuing to Pendulum and Amplitude

### DIFF
--- a/src/pages/spacewalk/bridge/Issue/index.tsx
+++ b/src/pages/spacewalk/bridge/Issue/index.tsx
@@ -21,7 +21,7 @@ import { TenantName } from '../../../../models/Tenant';
 import { ToastMessage, showToast } from '../../../../shared/showToast';
 
 import { FeeBox } from '../FeeBox';
-import { prioritizeXLMAsset } from '../helpers';
+import { filterHiddenAssets, prioritizeXLMAsset } from '../helpers';
 
 import { ConfirmationDialog } from './ConfirmationDialog';
 import Disclaimer from './Disclaimer';
@@ -101,7 +101,7 @@ function Issue(props: IssueProps): JSX.Element {
           operator program, more
           <a
             target="_blank"
-            className="text-primary ml-1"
+            className="ml-1 text-primary"
             href="https://pendulum.gitbook.io/pendulum-docs/build/spacewalk-stellar-bridge/operating-a-vault"
             rel="noreferrer"
           >
@@ -194,7 +194,7 @@ function Issue(props: IssueProps): JSX.Element {
   }, [trigger, selectedAsset, maxIssuable]);
 
   return (
-    <div className="flex items-center justify-center h-full space-walk py-4">
+    <div className="space-walk flex h-full items-center justify-center py-4">
       <ConfirmationDialog
         issueRequest={submittedIssueRequest}
         visible={confirmationDialogVisible}
@@ -205,7 +205,7 @@ function Issue(props: IssueProps): JSX.Element {
         }}
       />
       <div className="w-full">
-        <form className="px-5 flex flex-col" onSubmit={handleSubmit(submitRequestIssueExtrinsic, () => undefined)}>
+        <form className="flex flex-col px-5" onSubmit={handleSubmit(submitRequestIssueExtrinsic, () => undefined)}>
           <From
             {...{
               formControl: {
@@ -217,7 +217,7 @@ function Issue(props: IssueProps): JSX.Element {
                   (!isU128Compatible(amountNative) ? 'Exceeds the max allowed value.' : ''),
               },
               asset: {
-                assets: prioritizeXLMAsset(wrappedAssets),
+                assets: prioritizeXLMAsset(filterHiddenAssets(wrappedAssets)),
                 selectedAsset,
                 setSelectedAsset,
               },
@@ -228,7 +228,7 @@ function Issue(props: IssueProps): JSX.Element {
             }}
           />
           <input type="hidden" {...register('securityDeposit')} />
-          <label className="label flex align-center">
+          <label className="align-center label flex">
             <span className="text-sm">{`Max issuable: ${maxIssuable.toFixed(2)} ${selectedAsset?.code || ''}`}</span>
           </label>
 

--- a/src/pages/spacewalk/bridge/helpers.ts
+++ b/src/pages/spacewalk/bridge/helpers.ts
@@ -1,9 +1,25 @@
 import { Asset } from 'stellar-base';
 
+const MYKOBO_EURC = new Asset('EURC', 'GAQRF3UGHBT6JYQZ7YSUYCIYWAF4T2SAA5237Q5LIQYJOHHFAWDXZ7NM');
+const HIDDEN_SPACEWALK_ASSETS = [MYKOBO_EURC];
+
 export function prioritizeXLMAsset(assets?: Asset[]): Asset[] {
   if (!assets) {
     return [];
   }
 
   return assets.sort((a, b) => (a.code === 'XLM' ? -1 : b.code === 'XLM' ? 1 : 0));
+}
+
+// Filter out hardcoded hidden assets
+export function filterHiddenAssets(assets?: Asset[]): Asset[] {
+  if (!assets) {
+    return [];
+  }
+
+  return assets.filter((asset) => {
+    const isHidden = Boolean(HIDDEN_SPACEWALK_ASSETS.find((hidden) => hidden.equals(asset)));
+    console.log('isHidden', isHidden, 'asset', asset);
+    return !isHidden;
+  });
 }

--- a/src/pages/spacewalk/bridge/helpers.ts
+++ b/src/pages/spacewalk/bridge/helpers.ts
@@ -19,7 +19,6 @@ export function filterHiddenAssets(assets?: Asset[]): Asset[] {
 
   return assets.filter((asset) => {
     const isHidden = Boolean(HIDDEN_SPACEWALK_ASSETS.find((hidden) => hidden.equals(asset)));
-    console.log('isHidden', isHidden, 'asset', asset);
     return !isHidden;
   });
 }


### PR DESCRIPTION
Adds a new function to filter hidden assets and uses it for the assets shown in the issuing dialogs. 

Closes #522. 