### PR TITLE
Fix manual vault selection not changing vault

### DIFF
--- a/src/hooks/spacewalk/useBridgeSettings.ts
+++ b/src/hooks/spacewalk/useBridgeSettings.ts
@@ -25,10 +25,15 @@ export interface BridgeSettings {
 
 function useBridgeSettings(): BridgeSettings {
   const [extendedVaults, setExtendedVaults] = useState<ExtendedRegistryVault[]>();
-  const [manualVaultSelection, setManualVaultSelection] = useState(false);
   const { getVaults, getVaultsWithIssuableTokens, getVaultsWithRedeemableTokens } = useVaultRegistryPallet();
-  const [selectedVault, setSelectedVault] = useState<ExtendedRegistryVault>();
-  const { selectedAsset, setSelectedAsset } = (useContext(BridgeContext) || {}) as any;
+  const {
+    selectedAsset,
+    setSelectedAsset,
+    selectedVault,
+    setSelectedVault,
+    manualVaultSelection,
+    setManualVaultSelection,
+  } = (useContext(BridgeContext) || {}) as any;
   const { tenantName } = useGlobalState();
 
   useEffect(() => {
@@ -94,7 +99,15 @@ function useBridgeSettings(): BridgeSettings {
         }
       }
     }
-  }, [manualVaultSelection, selectedAsset, selectedVault, setSelectedAsset, vaultsForCurrency, wrappedAssets]);
+  }, [
+    manualVaultSelection,
+    selectedAsset,
+    selectedVault,
+    setSelectedAsset,
+    setSelectedVault,
+    vaultsForCurrency,
+    wrappedAssets,
+  ]);
 
   return {
     selectedVault,

--- a/src/hooks/spacewalk/useBridgeSettings.ts
+++ b/src/hooks/spacewalk/useBridgeSettings.ts
@@ -7,7 +7,7 @@ import { useGlobalState } from '../../GlobalStateProvider';
 import { convertCurrencyToStellarAsset, shouldFilterOut } from '../../helpers/spacewalk';
 import { stringifyStellarAsset } from '../../helpers/stellar';
 import { BridgeContext } from '../../pages/spacewalk/bridge';
-import { ExtendedRegistryVault, useVaultRegistryPallet } from './useVaultRegistryPallet';
+import { equalExtendedVaults, ExtendedRegistryVault, useVaultRegistryPallet } from './useVaultRegistryPallet';
 import { ToastMessage, showToast } from '../../shared/showToast';
 import { Balance } from '@polkadot/types/interfaces';
 
@@ -94,7 +94,11 @@ function useBridgeSettings(): BridgeSettings {
         }
       } else {
         // If the user manually selected a vault, but it's not available anymore, we reset the selection
-        if (selectedVault && !vaultsForCurrency.includes(selectedVault) && vaultsForCurrency.length > 0) {
+        if (
+          selectedVault &&
+          !vaultsForCurrency.some((a) => equalExtendedVaults(a, selectedVault)) &&
+          vaultsForCurrency.length > 0
+        ) {
           setSelectedVault(vaultsForCurrency[0]);
         }
       }

--- a/src/hooks/spacewalk/useBridgeSettings.ts
+++ b/src/hooks/spacewalk/useBridgeSettings.ts
@@ -1,15 +1,14 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import _ from 'lodash';
-import { useContext, useEffect, useMemo, useState } from 'preact/compat';
+import { Balance } from '@polkadot/types/interfaces';
+import { useEffect, useMemo, useState } from 'preact/compat';
 import { StateUpdater, Dispatch } from 'preact/hooks';
 import { Asset } from 'stellar-sdk';
+import _ from 'lodash';
 import { useGlobalState } from '../../GlobalStateProvider';
 import { convertCurrencyToStellarAsset, shouldFilterOut } from '../../helpers/spacewalk';
 import { stringifyStellarAsset } from '../../helpers/stellar';
-import { BridgeContext } from '../../pages/spacewalk/bridge';
 import { equalExtendedVaults, ExtendedRegistryVault, useVaultRegistryPallet } from './useVaultRegistryPallet';
 import { ToastMessage, showToast } from '../../shared/showToast';
-import { Balance } from '@polkadot/types/interfaces';
+import { useBridgeContext } from '../../pages/spacewalk/bridge';
 
 export interface BridgeSettings {
   selectedVault?: ExtendedRegistryVault;
@@ -33,14 +32,15 @@ function useBridgeSettings(): BridgeSettings {
     setSelectedVault,
     manualVaultSelection,
     setManualVaultSelection,
-  } = (useContext(BridgeContext) || {}) as any;
+  } = useBridgeContext();
+
   const { tenantName } = useGlobalState();
 
   useEffect(() => {
     const combinedVaults: ExtendedRegistryVault[] = [];
     Promise.all([getVaultsWithIssuableTokens(), getVaultsWithRedeemableTokens()])
       .then(([vaultsWithIssuableTokens, vaultsWithRedeemableTokens]) => {
-        getVaults().forEach((vaultFromRegistry: any) => {
+        getVaults().forEach((vaultFromRegistry) => {
           const vaultWithIssuable = vaultsWithIssuableTokens?.find(([id, _]) => id.eq(vaultFromRegistry.id));
           const vaultWithRedeemable = vaultsWithRedeemableTokens?.find(([id, _]) => id.eq(vaultFromRegistry.id));
           const extended: ExtendedRegistryVault = vaultFromRegistry;

--- a/src/hooks/spacewalk/useVaultRegistryPallet.ts
+++ b/src/hooks/spacewalk/useVaultRegistryPallet.ts
@@ -10,6 +10,10 @@ export interface ExtendedRegistryVault extends VaultRegistryVault {
   redeemableTokens?: Balance;
 }
 
+export function equalExtendedVaults(a: ExtendedRegistryVault, b: ExtendedRegistryVault) {
+  return a.id.eq(b.id);
+}
+
 export function useVaultRegistryPallet() {
   const { api } = useNodeInfoState().state;
 

--- a/src/pages/spacewalk/bridge/Issue/SettingsDialog.tsx
+++ b/src/pages/spacewalk/bridge/Issue/SettingsDialog.tsx
@@ -19,7 +19,7 @@ export function SettingsDialog({ bridgeDirection, visible, onClose }: Props) {
   const content = useMemo(
     () => (
       <div className="text-center">
-        <div className="flex mt-4 align-center">
+        <div className="align-center mt-4 flex">
           <Checkbox
             size="sm"
             color="success"
@@ -28,13 +28,13 @@ export function SettingsDialog({ bridgeDirection, visible, onClose }: Props) {
                 setManualVaultSelection(e.target.checked);
               }
             }}
-            className="rounded checkbox"
+            className="checkbox rounded"
             checked={manualVaultSelection}
           />
           <span className="ml-2">Manually select vault</span>
         </div>
         {manualVaultSelection && vaultsForCurrency && (
-          <div className="flex flex-col items-start justify-start mt-4">
+          <div className="mt-4 flex flex-col items-start justify-start">
             <div>Select Vault</div>
             <VaultSelector
               vaults={vaultsForCurrency}
@@ -46,7 +46,14 @@ export function SettingsDialog({ bridgeDirection, visible, onClose }: Props) {
         )}
       </div>
     ),
-    [manualVaultSelection, vaultsForCurrency, setSelectedVault, selectedVault, setManualVaultSelection],
+    [
+      manualVaultSelection,
+      vaultsForCurrency,
+      setSelectedVault,
+      selectedVault,
+      bridgeDirection,
+      setManualVaultSelection,
+    ],
   );
 
   const actions = useMemo(

--- a/src/pages/spacewalk/bridge/index.tsx
+++ b/src/pages/spacewalk/bridge/index.tsx
@@ -1,5 +1,5 @@
-import { createContext, useEffect } from 'preact/compat';
-import { StateUpdater, Dispatch, useMemo, useState } from 'preact/hooks';
+import { createContext } from 'preact/compat';
+import { StateUpdater, Dispatch, useMemo, useState, useContext } from 'preact/hooks';
 import { Button, Card, Tabs } from 'react-daisyui';
 import { Asset } from 'stellar-sdk';
 import AmplitudeLogo from '../../../assets/AmplitudeLogo';
@@ -10,8 +10,8 @@ import { SpacewalkConstants } from '../../../helpers/spacewalk';
 import { ExtendedRegistryVault } from '../../../hooks/spacewalk/useVaultRegistryPallet';
 import { useNodeInfoState } from '../../../NodeInfoProvider';
 import { TenantName } from '../../../models/Tenant';
-import Issue from './Issue';
 import SettingsDialog from './Issue/SettingsDialog';
+import Issue from './Issue';
 import Redeem from './Redeem';
 import '../styles.css';
 
@@ -30,15 +30,18 @@ interface BridgeContextValue {
   setSelectedAsset: Dispatch<StateUpdater<Asset | undefined>>;
   selectedVault?: ExtendedRegistryVault;
   setSelectedVault: Dispatch<StateUpdater<ExtendedRegistryVault | undefined>>;
-  manualVaultSelection?: boolean;
+  manualVaultSelection: boolean;
   setManualVaultSelection: Dispatch<StateUpdater<boolean>>;
 }
 
-export const BridgeContext = createContext<BridgeContextValue>({
+const BridgeContext = createContext<BridgeContextValue>({
   setSelectedAsset: () => undefined,
   setSelectedVault: () => undefined,
   setManualVaultSelection: () => undefined,
+  manualVaultSelection: false,
 });
+
+export const useBridgeContext = () => useContext(BridgeContext);
 
 function Bridge(): JSX.Element | null {
   const [tabValue, setTabValue] = useState(BridgeTabs.Issue);


### PR DESCRIPTION
The problem was that some of the info that needed to be shared between the settings dialog and the issue/redeem form was stored locally in each call to `useBridgeSettings`. Moving the relevant items out of the state of the hook and into the context fixes this issue. 

Closes #553. 