### PR TITLE
Improve manual vault selection for spacewalk amplitude and pendulum

### DIFF
--- a/src/components/Selector/VaultSelector.tsx
+++ b/src/components/Selector/VaultSelector.tsx
@@ -18,9 +18,7 @@ function getMaxTokensForVault(vault: ExtendedRegistryVault, type: 'issue' | 'red
   if (!maxTokens) return '0';
 
   try {
-    const balance: { amount: string } = maxTokens.toJSON();
-
-    return nativeToDecimal(balance.amount.toString()).toFixed(2);
+    return nativeToDecimal(maxTokens).toFixed(2);
   } catch (error) {
     console.error('Error parsing max tokens', error);
     return '0';
@@ -31,16 +29,16 @@ function VaultSelector(props: VaultSelectorProps): JSX.Element {
   const { vaults, selectedVault, bridgeDirection, onChange } = props;
 
   return (
-    <div className="dropdown w-full mt-3">
+    <div className="dropdown mt-3 w-full">
       <Button
         type="button"
         color="ghost"
-        className="flex content-center place-content-between w-full border-base-200 bg-base-300 rounded-md no-animation"
+        className="no-animation flex w-full place-content-between content-center rounded-md border-base-200 bg-base-300"
       >
         <PublicKey publicKey={selectedVault ? selectedVault.id.accountId.toString() : ''} variant="full" />
-        <ChevronDownIcon className="w-3 h-3" stroke-width="2" />
+        <ChevronDownIcon className="h-3 w-3" stroke-width="2" />
       </Button>
-      <Dropdown.Menu className="dropdown-content w-full mt-1.5 p-1 border border-base-200 bg-base-300 rounded-md shadow-none">
+      <Dropdown.Menu className="dropdown-content mt-1.5 w-full rounded-md border border-base-200 bg-base-300 p-1 shadow-none">
         {vaults.map((vault) => (
           <Dropdown.Item
             key={vault.id.accountId.toString()}
@@ -51,9 +49,9 @@ function VaultSelector(props: VaultSelectorProps): JSX.Element {
               }
               onChange(vault);
             }}
-            className="w-full rounded-md flex"
+            className="flex w-full rounded-md"
           >
-            <span className="w-full flex place-content-between">
+            <span className="flex w-full place-content-between">
               <span className="flex">
                 <PublicKey publicKey={vault.id.accountId.toString()} variant="short" />
               </span>

--- a/src/hooks/spacewalk/useBridgeSettings.ts
+++ b/src/hooks/spacewalk/useBridgeSettings.ts
@@ -58,7 +58,6 @@ function findBestVaultForAsset(
 }
 
 function useBridgeSettings(): BridgeSettings {
-  const [extendedVaults, setExtendedVaults] = useState<ExtendedRegistryVault[]>();
   const { getVaults, getVaultsWithIssuableTokens, getVaultsWithRedeemableTokens } = useVaultRegistryPallet();
   const {
     selectedAsset,
@@ -68,6 +67,8 @@ function useBridgeSettings(): BridgeSettings {
     manualVaultSelection,
     setManualVaultSelection,
     bridgeDirection,
+    extendedVaults,
+    setExtendedVaults,
   } = useBridgeContext();
 
   const { tenantName } = useGlobalState();
@@ -125,16 +126,14 @@ function useBridgeSettings(): BridgeSettings {
   useEffect(() => {
     if (vaultsForCurrency && wrappedAssets) {
       if (!manualVaultSelection) {
-        if (vaultsForCurrency.length > 0) {
-          const bestVault = findBestVaultForAsset(
-            vaultsForCurrency,
-            selectedAsset || wrappedAssets[0],
-            bridgeDirection,
-          );
+        if (vaultsForCurrency.length > 0 && selectedAsset) {
+          const bestVault = findBestVaultForAsset(vaultsForCurrency, selectedAsset, bridgeDirection);
           setSelectedVault(bestVault);
         }
         if (!selectedAsset && wrappedAssets.length > 0) {
-          setSelectedAsset(wrappedAssets[0]);
+          // Try to select the xlm asset by default
+          const xlmAsset = wrappedAssets.find((asset) => asset.getCode() === 'XLM');
+          setSelectedAsset(xlmAsset || wrappedAssets[0]);
         }
       } else {
         // If the user manually selected a vault, but it's not available anymore, we reset the selection

--- a/src/hooks/spacewalk/useBridgeSettings.ts
+++ b/src/hooks/spacewalk/useBridgeSettings.ts
@@ -1,5 +1,5 @@
 import Big from 'big.js';
-import { useEffect, useMemo, useState } from 'preact/compat';
+import { useEffect, useMemo } from 'preact/compat';
 import { StateUpdater, Dispatch } from 'preact/hooks';
 import { Asset } from 'stellar-sdk';
 import _ from 'lodash';
@@ -35,7 +35,7 @@ function findBestVaultForAsset(
   });
 
   if (vaultsWithAsset.length === 0) {
-    return undefined;
+    return;
   }
 
   return vaultsWithAsset.reduce((bestVault, currentVault) => {
@@ -82,10 +82,10 @@ function useBridgeSettings(): BridgeSettings {
           const vaultWithRedeemable = vaultsWithRedeemableTokens?.find(([id, _]) => id.eq(vaultFromRegistry.id));
           const extended: ExtendedRegistryVault = vaultFromRegistry;
           extended.issuableTokens = vaultWithIssuable
-            ? new Big((vaultWithIssuable[1].toJSON() as unknown as { amount: string }).amount)
+            ? new Big((vaultWithIssuable[1].toJSON() as { amount: string }).amount)
             : undefined;
           extended.redeemableTokens = vaultWithRedeemable
-            ? new Big((vaultWithRedeemable[1].toJSON() as unknown as { amount: string }).amount)
+            ? new Big((vaultWithRedeemable[1].toJSON() as { amount: string }).amount)
             : undefined;
           combinedVaults.push(extended);
         });

--- a/src/hooks/spacewalk/useVaultRegistryPallet.ts
+++ b/src/hooks/spacewalk/useVaultRegistryPallet.ts
@@ -1,13 +1,14 @@
 import { AccountId32, Balance } from '@polkadot/types/interfaces';
 import type { VaultRegistryVault } from '@polkadot/types/lookup';
+import Big from 'big.js';
 import { useEffect, useMemo, useState } from 'preact/hooks';
 import { useNodeInfoState } from '../../NodeInfoProvider';
 import { convertRawHexKeyToPublicKey } from '../../helpers/stellar';
 import { isEmpty } from 'lodash';
 
 export interface ExtendedRegistryVault extends VaultRegistryVault {
-  issuableTokens?: Balance;
-  redeemableTokens?: Balance;
+  issuableTokens?: Big;
+  redeemableTokens?: Big;
 }
 
 export function equalExtendedVaults(a: ExtendedRegistryVault, b: ExtendedRegistryVault) {

--- a/src/hooks/spacewalk/useVaultRegistryPallet.ts
+++ b/src/hooks/spacewalk/useVaultRegistryPallet.ts
@@ -1,4 +1,4 @@
-import { AccountId32, Balance } from '@polkadot/types/interfaces';
+import { AccountId32 } from '@polkadot/types/interfaces';
 import type { VaultRegistryVault } from '@polkadot/types/lookup';
 import Big from 'big.js';
 import { useEffect, useMemo, useState } from 'preact/hooks';

--- a/src/pages/spacewalk/bridge/Issue/index.tsx
+++ b/src/pages/spacewalk/bridge/Issue/index.tsx
@@ -70,9 +70,7 @@ function Issue(props: IssueProps): JSX.Element {
   const { balances } = useAccountBalance();
   const { transferable } = balances;
 
-  const issuableTokens = selectedVault?.issuableTokens?.toJSON?.().amount ?? selectedVault?.issuableTokens;
-
-  const maxIssuable = nativeToDecimal(issuableTokens || 0).toNumber();
+  const maxIssuable = nativeToDecimal(selectedVault?.issuableTokens || 0).toNumber();
 
   const { handleSubmit, watch, register, formState, setValue, trigger } = useForm<IssueFormValues>({
     resolver: yupResolver(getIssueValidationSchema(maxIssuable, parseFloat(transferable || '0.0'), tokenSymbol)),

--- a/src/pages/spacewalk/bridge/Redeem/index.tsx
+++ b/src/pages/spacewalk/bridge/Redeem/index.tsx
@@ -57,8 +57,7 @@ function Redeem(props: RedeemProps): JSX.Element {
     setSelectedAssetsBalance(amount);
   }, [balances, selectedAsset, wrappedCurrencySuffix, selectedAssetsBalance]);
 
-  const redeemableTokens = selectedVault?.redeemableTokens?.toJSON?.().amount ?? selectedVault?.redeemableTokens;
-  const maxRedeemable = nativeToDecimal(redeemableTokens || 0).toNumber();
+  const maxRedeemable = nativeToDecimal(selectedVault?.redeemableTokens || 0).toNumber();
 
   const { handleSubmit, watch, register, formState, setValue, trigger } = useForm<RedeemFormValues>({
     defaultValues: {},

--- a/src/pages/spacewalk/bridge/index.tsx
+++ b/src/pages/spacewalk/bridge/index.tsx
@@ -33,14 +33,18 @@ interface BridgeContextValue {
   manualVaultSelection: boolean;
   setManualVaultSelection: Dispatch<StateUpdater<boolean>>;
   bridgeDirection: BridgeDirection;
+  extendedVaults: ExtendedRegistryVault[];
+  setExtendedVaults: Dispatch<StateUpdater<ExtendedRegistryVault[]>>;
 }
 
 const BridgeContext = createContext<BridgeContextValue>({
   setSelectedAsset: () => undefined,
   setSelectedVault: () => undefined,
-  setManualVaultSelection: () => undefined,
   manualVaultSelection: false,
+  setManualVaultSelection: () => undefined,
   bridgeDirection: BridgeDirection.Issue,
+  extendedVaults: [],
+  setExtendedVaults: () => undefined,
 });
 
 export const useBridgeContext = () => useContext(BridgeContext);
@@ -53,6 +57,7 @@ function Bridge(): JSX.Element | null {
   const [selectedAsset, setSelectedAsset] = useState<Asset>();
   const [selectedVault, setSelectedVault] = useState<ExtendedRegistryVault>();
   const [manualVaultSelection, setManualVaultSelection] = useState(false);
+  const [extendedVaults, setExtendedVaults] = useState<ExtendedRegistryVault[]>([]);
 
   const Content = useMemo(() => {
     if (!chain) return;
@@ -85,6 +90,8 @@ function Bridge(): JSX.Element | null {
         manualVaultSelection,
         setManualVaultSelection,
         bridgeDirection,
+        extendedVaults,
+        setExtendedVaults,
       }}
     >
       <div className="mt-4 flex h-full items-center justify-center">

--- a/src/pages/spacewalk/bridge/index.tsx
+++ b/src/pages/spacewalk/bridge/index.tsx
@@ -49,7 +49,7 @@ const BridgeContext = createContext<BridgeContextValue>({
 
 export const useBridgeContext = () => useContext(BridgeContext);
 
-function Bridge(): JSX.Element | null {
+function Bridge() {
   const [tabValue, setTabValue] = useState(BridgeTabs.Issue);
   const [settingsVisible, setSettingsVisible] = useState(false);
   const { chain, tokenSymbol } = useNodeInfoState().state;

--- a/src/pages/spacewalk/bridge/index.tsx
+++ b/src/pages/spacewalk/bridge/index.tsx
@@ -32,6 +32,7 @@ interface BridgeContextValue {
   setSelectedVault: Dispatch<StateUpdater<ExtendedRegistryVault | undefined>>;
   manualVaultSelection: boolean;
   setManualVaultSelection: Dispatch<StateUpdater<boolean>>;
+  bridgeDirection: BridgeDirection;
 }
 
 const BridgeContext = createContext<BridgeContextValue>({
@@ -39,6 +40,7 @@ const BridgeContext = createContext<BridgeContextValue>({
   setSelectedVault: () => undefined,
   setManualVaultSelection: () => undefined,
   manualVaultSelection: false,
+  bridgeDirection: BridgeDirection.Issue,
 });
 
 export const useBridgeContext = () => useContext(BridgeContext);
@@ -82,6 +84,7 @@ function Bridge(): JSX.Element | null {
         setSelectedVault,
         manualVaultSelection,
         setManualVaultSelection,
+        bridgeDirection,
       }}
     >
       <div className="mt-4 flex h-full items-center justify-center">


### PR DESCRIPTION
Changes the automatic vault selection to select the vault with the most issuable tokens (when bridging to Pendulum) or the vault with the most redeemable tokens (when bridging to Stellar) by default. 

Refactors the code a bit to simplify the usage of the `issuableTokens` and `redeemableTokens` on the `ExtendedVault` types. 

Closes #556.