### PR TITLE
configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,3 @@ updates:
       - "Sharqiewicz"
     reviewers:
       - "Sharqiewicz"
-    groups:
-      security-dependencies:
-        applies-to: security-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "fix"
+      prefix: "bot-chore:"
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "*"
@@ -17,9 +17,9 @@ updates:
       - "dependencies"
       - "security"
     assignees:
-      - "sharqiewicz"
+      - "Sharqiewicz"
     reviewers:
-      - "sharqiewicz"
+      - "Sharqiewicz"
     group:
       name: "all-dependencies"
       patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,7 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "bot-chore:"
-    open-pull-requests-limit: 10
-    ignore:
-      - dependency-name: "*"
-    security-updates: true
+    open-pull-requests-limit: 5
     rebase-strategy: "auto"
     pull-request-branch-name:
       separator: "-"
@@ -21,6 +18,6 @@ updates:
     reviewers:
       - "Sharqiewicz"
     group:
-      name: "all-dependencies"
+      name: "security-dependencies"
       patterns:
         - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "fix"
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+    security-updates: true
+    rebase-strategy: "auto"
+    pull-request-branch-name:
+      separator: "-"
+    labels:
+      - "dependencies"
+      - "security"
+    assignees:
+      - "sharqiewicz"
+    reviewers:
+      - "sharqiewicz"
+    group:
+      name: "all-dependencies"
+      patterns:
+        - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,6 @@ updates:
       - "Sharqiewicz"
     reviewers:
       - "Sharqiewicz"
-    group:
-      name: "security-dependencies"
-      patterns:
-        - "*"
+    groups:
+      security-dependencies:
+        applies-to: security-updates


### PR DESCRIPTION
🦈 PR - in progress
---

Dependabot will check daily for new versions of dependencies but will only apply updates for security vulnerabilities. Non-security updates are ignored to reduce noise. The packages will be updated to the latest versions [?].

Pull requests created by Dependabot will be prefixed with “bot-chore” in their commit messages, limited to a maximum of 5 open PRs. Each PR will be automatically labeled with “dependencies” and “security,” assigned to @Sharqiewicz . All updates will be grouped into a single PR for easier management.