### PR TITLE
Enable USDC Asset Hub instance of Forex AMM

### DIFF
--- a/src/config/apps/nabla.ts
+++ b/src/config/apps/nabla.ts
@@ -23,7 +23,7 @@ export const nablaConfig: NablaConfig = {
   },
   pendulum: {
     indexerUrl: 'https://pendulum.squids.live/pendulum-squid/graphql',
-    router: '6fEJAs1ycfTNDZY7ZoAtkBhuhHnRVNscdALMBLdjDV12K4uE',
-    oracle: '6fxpVAp3W5mJsXqnBiQresTd8HZDkNMRFCafbXC9X2AAjFHY',
+    router: '6gAVVw13mQgzzKk4yEwScMmWiCNyMAunXFJUZonbgKrym81N',
+    oracle: '6fzZ96uMJwPyMz9W8SRL7JfhFKc8GzG95YREHkV8kBJagkyV',
   },
 };


### PR DESCRIPTION
Closes #618.

Don't merge this PR. This should stay unmerged for now so that we can use the Netlify deployment for accessing this Nabla instance and to be able to provide liquidity.