### PR TITLE
Change batching server endpoint

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -3,4 +3,4 @@ export const SECONDS_IN_A_DAY = 86400;
 export const BLOCK_TIME_SEC = 12;
 
 export const PENDULUM_SUPPORT_CHAT_URL = 'https://discord.com/channels/841944723979108403/1247164487883292672';
-export const BATCHING_SERVER_URL = 'https://batching-server.pendulumchain.tech/currencies';
+export const BATCHING_SERVER_URL = 'https://eu-api.pendulumchain.tech/currencies';


### PR DESCRIPTION
Closes #620.

Note that the deploy preview will not show the prices either as the cors setting only allows portal.pendulumchain.org to query from the endpoint. To confirm that the query works you can use curl and query it locally though.

Works
```
$ curl -X POST https://eu-api.pendulumchain.tech/currencies -H "Content-Type: application/json" -d '[{"blockchain": "FIAT", "symbol": "BRL-USD"}]'
[{"symbol":"BRL-USD","name":"BRL-USD","blockchain":"FIAT","supply":0,"lastUpdateTimestamp":1731676265,"price":172491116707}]%                                                                                                                        
```
Doesn't work
```
$ curl -X POST https://batching-server.pendulumchain.tech/currencies -H "Content-Type: application/json" -d '[{"blockchain": "FIAT", "symbol": "BRL-USD"}]'
curl: (60) SSL: no alternative certificate subject name matches target host name 'batching-server.pendulumchain.tech'
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```