### PR TITLE
Fix alchemypay redirect not prefilling PEN

### DIFF
--- a/netlify/functions/alchemypay.mts
+++ b/netlify/functions/alchemypay.mts
@@ -84,7 +84,7 @@ export default async (req: Request, context: Context) => {
     showTable: showTable,
     redirectURL: redirectURL,
 
-    crypto: 'PEN',
+    crypto: 'PENDULUM',
     merchantOrderNo: merchantOrderNo,
     network: 'PEN',
     timestamp: timestamp,

--- a/src/pages/fund-wallet/FundWalletTabsContent/helpers.tsx
+++ b/src/pages/fund-wallet/FundWalletTabsContent/helpers.tsx
@@ -25,7 +25,7 @@ const EXCHANGE_LIST: Record<FundSupportedTenants, { buy: CardExternalLinkProps[]
         {
           title: 'Banxa',
           children: <img src={banxaIcon} className="ml-2 w-40" />,
-          href: 'https://checkout.banxa.com/',
+          href: 'https://checkout.banxa.com/?coinType=PEN&fiatType=EUR',
         },
       ],
       exchange: [


### PR DESCRIPTION
AlchemyPay changed the naming of the `crypto` parameter for the PEN token. We need to change it to make our redirect work again.