### PR TITLE
Fix buggy calculation of transferable amount for security deposit

### DIFF
--- a/src/components/Wallet/modals/DisconnectModal/index.tsx
+++ b/src/components/Wallet/modals/DisconnectModal/index.tsx
@@ -67,7 +67,7 @@ const WalletDropdownMenu = ({
       />
     </div>
     <p className="my-6 truncate text-center text-2xl font-bold" title={`${balance} ${tokenSymbol}`}>
-      {balance} {tokenSymbol}
+      {balance && prettyNumbers(balance)} {tokenSymbol}
     </p>
     <Button className="bg-base-300" size="sm" onClick={removeWalletAccount}>
       <ArrowLeftEndOnRectangleIcon className="mr-2 w-5" />

--- a/src/components/Wallet/modals/DisconnectModal/index.tsx
+++ b/src/components/Wallet/modals/DisconnectModal/index.tsx
@@ -10,11 +10,12 @@ import { useAccountBalance } from '../../../../shared/useAccountBalance';
 import { useGlobalState } from '../../../../GlobalStateProvider';
 import { CopyablePublicKey } from '../../../PublicKey/CopyablePublicKey';
 import { Skeleton } from '../../../Skeleton';
+import { prettyNumbers } from '../../../../shared/parseNumbers/metric';
 
 interface WalletButtonProps {
   wallet?: Wallet;
   query: UseQueryResult<FrameSystemAccountInfo | undefined, unknown>;
-  balance?: string;
+  balance?: number;
   tokenSymbol?: string;
   walletAccount?: WalletAccount;
 }
@@ -31,7 +32,7 @@ const WalletButton = ({ wallet, query, balance, tokenSymbol, walletAccount }: Wa
       <Skeleton className="mr-2 hidden bg-[rgba(0,0,0,.06)] px-2 py-1 sm:flex">10000.00 TKN</Skeleton>
     ) : (
       <span className="mr-2 hidden items-center rounded-lg bg-[rgba(0,0,0,.06)] px-2 py-0.5 sm:flex">
-        {balance} {tokenSymbol}
+        {balance && prettyNumbers(balance)} {tokenSymbol}
       </span>
     )}
     <p className="hidden truncate sm:block">{walletAccount?.name}</p>
@@ -41,7 +42,7 @@ const WalletButton = ({ wallet, query, balance, tokenSymbol, walletAccount }: Wa
 
 interface WalletDropdownMenuProps {
   address: string;
-  balance?: string;
+  balance?: number;
   tokenSymbol?: string;
   walletAccount?: WalletAccount;
   ss58Format?: number;
@@ -65,11 +66,11 @@ const WalletDropdownMenu = ({
         inline={true}
       />
     </div>
-    <p className="my-6 text-2xl font-bold text-center truncate" title={`${balance} ${tokenSymbol}`}>
+    <p className="my-6 truncate text-center text-2xl font-bold" title={`${balance} ${tokenSymbol}`}>
       {balance} {tokenSymbol}
     </p>
     <Button className="bg-base-300" size="sm" onClick={removeWalletAccount}>
-      <ArrowLeftEndOnRectangleIcon className="w-5 mr-2" />
+      <ArrowLeftEndOnRectangleIcon className="mr-2 w-5" />
       Disconnect
     </Button>
   </Dropdown.Menu>

--- a/src/pages/spacewalk/bridge/Issue/index.tsx
+++ b/src/pages/spacewalk/bridge/Issue/index.tsx
@@ -73,7 +73,7 @@ function Issue(props: IssueProps): JSX.Element {
   const maxIssuable = nativeToDecimal(selectedVault?.issuableTokens || 0).toNumber();
 
   const { handleSubmit, watch, register, formState, setValue, trigger } = useForm<IssueFormValues>({
-    resolver: yupResolver(getIssueValidationSchema(maxIssuable, parseFloat(transferable || '0.0'), tokenSymbol)),
+    resolver: yupResolver(getIssueValidationSchema(maxIssuable, transferable, tokenSymbol)),
     mode: 'onChange',
   });
 

--- a/src/shared/useAccountBalance.ts
+++ b/src/shared/useAccountBalance.ts
@@ -2,14 +2,14 @@ import { FrameSystemAccountInfo } from '@polkadot/types/lookup';
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { emptyCacheKey, QueryOptions } from './helpers';
-import { nativeToDecimal, prettyNumbers } from './parseNumbers/metric';
+import { nativeToDecimal } from './parseNumbers/metric';
 import { useSharedState } from './Provider';
 import { cacheKeys } from '../constants/cache';
 import { calculateTransferableBalance } from '../helpers/substrate';
 
 export interface UseAccountBalanceResponse {
   query: UseQueryResult<FrameSystemAccountInfo | undefined, unknown>;
-  balances: { total: string; transferable: string };
+  balances: { total: number; transferable: number };
   enabled: boolean;
 }
 
@@ -47,15 +47,15 @@ export const useAccountBalance = (
   const decimals = options?.decimals;
 
   const balances = useMemo(() => {
-    if (!data || !data?.data) return { total: '0', transferable: '0' };
+    if (!data || !data?.data) return { total: 0, transferable: 0 };
 
     const { free: freeRaw, frozen: frozenRaw, reserved: reservedRaw } = data.data;
 
     const free = nativeToDecimal(freeRaw || 0, decimals);
     const frozen = nativeToDecimal(frozenRaw || 0, decimals);
     const reserved = nativeToDecimal(reservedRaw || 0, decimals);
-    const total = prettyNumbers(free.toNumber());
-    const transferable = prettyNumbers(calculateTransferableBalance(free, frozen, reserved).toNumber());
+    const total = free.toNumber();
+    const transferable = calculateTransferableBalance(free, frozen, reserved).toNumber();
     return { total, transferable };
   }, [data, decimals]);
 


### PR DESCRIPTION
The problem occurs only for accounts with a large balance of PEN tokens. The `useAccountBalance` hook returned the values with _pretty formatting_. This means that large amounts were depicted with commas, e.g. `10,000.00`.  The consumer of this balance could wrongly interpret the number as 10 PEN (if the comma is expected to denote the decimals) which is exactly what happened when transforming the transferable balance for calculating the security deposit. 

This PR changes the return type of `useAccountBalance` to return numbers instead. 

Closes #631. 