### PR TITLE
Fix crash when address is copied to clipboard.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react-hook-form": "^7.53.0",
     "react-lottie": "^1.2.10",
     "react-router-dom": "^6.27.0",
-    "react-toastify": "^9.1.3",
+    "react-toastify": "^11.0.2",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "yup": "^1.4.0"

--- a/src/shared/showToast.ts
+++ b/src/shared/showToast.ts
@@ -23,59 +23,59 @@ const ToastProperties: Record<ToastMessage, ToastSettings> = {
     message: 'Could not establish connection with the bridge...',
     options: {
       toastId: ToastMessage.BRIDGE_CONNECTION_ERROR,
-      type: toast.TYPE.ERROR,
+      type: 'error',
     },
   },
   [ToastMessage.NODE_CONNECTION_ERROR]: {
     message: 'Error while connecting to the node. Refresh the page to re-connect.',
     options: {
       toastId: ToastMessage.NODE_CONNECTION_ERROR,
-      type: toast.TYPE.ERROR,
+      type: 'error',
     },
   },
   [ToastMessage.TX_SUBMISSION_FAILED]: {
     message: 'Transaction submission failed',
     options: {
       toastId: ToastMessage.TX_SUBMISSION_FAILED,
-      type: toast.TYPE.ERROR,
+      type: 'error',
     },
   },
   [ToastMessage.UPDATED_DELEGATOR_REWARDS]: {
     message: 'Delegator rewards updated',
     options: {
       toastId: ToastMessage.UPDATED_DELEGATOR_REWARDS,
-      type: toast.TYPE.SUCCESS,
+      type: 'error',
     },
   },
   [ToastMessage.NO_WALLET_SELECTED]: {
     message: 'No wallet account selected',
     options: {
       toastId: ToastMessage.NO_WALLET_SELECTED,
-      type: toast.TYPE.ERROR,
+      type: 'error',
     },
   },
   [ToastMessage.ERROR]: {
     message: 'An error occurred',
     options: {
-      type: toast.TYPE.ERROR,
+      type: 'error',
     },
   },
   [ToastMessage.INFO]: {
     message: 'Info',
     options: {
-      type: toast.TYPE.INFO,
+      type: 'info',
     },
   },
   [ToastMessage.WARNING]: {
     message: 'Warning',
     options: {
-      type: toast.TYPE.WARNING,
+      type: 'warning',
     },
   },
   [ToastMessage.BUYOUT_ERROR]: {
     message: 'A buyout error occurred',
     options: {
-      type: toast.TYPE.ERROR,
+      type: 'error',
       toastId: ToastMessage.BUYOUT_ERROR,
     },
   },
@@ -83,7 +83,7 @@ const ToastProperties: Record<ToastMessage, ToastSettings> = {
     message: 'There is already an open pending connection for this wallet. Please close it and try again.',
     options: {
       toastId: ToastMessage.WALLET_ALREADY_OPEN_PENDING_CONNECTION,
-      type: toast.TYPE.WARNING,
+      type: 'warning',
     },
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6345,10 +6345,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^1.1.1":
-  version: 1.2.1
-  resolution: "clsx@npm:1.2.1"
-  checksum: 10c0/34dead8bee24f5e96f6e7937d711978380647e936a22e76380290e35486afd8634966ce300fc4b74a32f3762c7d4c0303f442c3e259f4ce02374eb0c82834f27
+"clsx@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "clsx@npm:2.1.1"
+  checksum: 10c0/c4c8eb865f8c82baab07e71bfa8897c73454881c4f99d6bc81585aecd7c441746c1399d08363dc096c550cceaf97bd4ce1e8854e1771e9998d9f94c4fe075839
   languageName: node
   linkType: hard
 
@@ -11814,7 +11814,7 @@ __metadata:
     react-hook-form: "npm:^7.53.0"
     react-lottie: "npm:^1.2.10"
     react-router-dom: "npm:^6.27.0"
-    react-toastify: "npm:^9.1.3"
+    react-toastify: "npm:^11.0.2"
     tailwindcss: "npm:^3.4.14"
     ts-jest: "npm:^29.2.5"
     ts-node: "npm:^10.9.2"
@@ -12843,15 +12843,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-toastify@npm:^9.1.3":
-  version: 9.1.3
-  resolution: "react-toastify@npm:9.1.3"
+"react-toastify@npm:^11.0.2":
+  version: 11.0.2
+  resolution: "react-toastify@npm:11.0.2"
   dependencies:
-    clsx: "npm:^1.1.1"
+    clsx: "npm:^2.1.1"
   peerDependencies:
-    react: ">=16"
-    react-dom: ">=16"
-  checksum: 10c0/51de1e51e9357a24773fbcd45a4db18bf74b8ec40d86a2bfb4a4fee23ca4f9fffdac5dfb7a3c21baea39971f72f72dfcdc79403a6de006f74d69e7bc12f8b3e0
+    react: ^18 || ^19
+    react-dom: ^18 || ^19
+  checksum: 10c0/e1ba01846782d47d0bf9cec7e2b4804f9af30e50a203786523f16db33691c1491f2382832e7ec4b69c583d3634ea0e3efb383da00ca9076bcf4bdd906a54a85f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What:

A bug was detected that would crash the application when `CopyablePublicKey` was used (and clicked). Root cause was an undetermined bug in `react-toastify`, when `toast` was called.

### How:

Simply updating the dependency solved the issue.
