### PR TITLE
Point to other amm instance

### DIFF
--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -123,7 +123,7 @@ const Table = <T,>({
   return (
     <>
       {search ? (
-        <div className="mb-2 flex flex-row flex-wrap gap-2">
+        <div className="mb-2 flex flex-row flex-wrap gap-2 self-end">
           <div className="ml-auto">
             <GlobalFilter globalFilter={globalFilter} setGlobalFilter={setGlobalFilter} />
           </div>

--- a/src/components/nabla/common/OldForexAmmNotice.tsx
+++ b/src/components/nabla/common/OldForexAmmNotice.tsx
@@ -6,14 +6,14 @@ export function OldForexAmmNotice() {
       <div className="flex w-fit items-center gap-2 rounded-md bg-gray-200 p-2 text-gray-800">
         <InformationCircleIcon className="h-4" />
         <span>
-          You can find the old instance of the Forex AMM on{' '}
+          You can access the old instance of the Forex AMM{' '}
           <a
             className="text-primary transition hover:underline"
             href="https://old-forex-amm--rococo-souffle-a625f5.netlify.app/pendulum/nabla/swap"
           >
-            this
-          </a>{' '}
-          page.
+            here
+          </a>
+          .
         </span>
       </div>
     </div>

--- a/src/components/nabla/common/OldForexAmmNotice.tsx
+++ b/src/components/nabla/common/OldForexAmmNotice.tsx
@@ -1,0 +1,19 @@
+import { InformationCircleIcon } from '@heroicons/react/24/outline';
+
+export function OldForexAmmNotice() {
+  return (
+    <div className="mb-4 flex items-center justify-center gap-2 rounded-md bg-gray-200 p-2 text-gray-800">
+      <InformationCircleIcon className="h-4" />
+      <span>
+        You can find the old instance of the Forex AMM on{' '}
+        <a
+          className="text-primary transition hover:underline"
+          href="https://old-forex-amm--rococo-souffle-a625f5.netlify.app/pendulum/nabla/swap"
+        >
+          this
+        </a>{' '}
+        page.
+      </span>
+    </div>
+  );
+}

--- a/src/components/nabla/common/OldForexAmmNotice.tsx
+++ b/src/components/nabla/common/OldForexAmmNotice.tsx
@@ -2,18 +2,20 @@ import { InformationCircleIcon } from '@heroicons/react/24/outline';
 
 export function OldForexAmmNotice() {
   return (
-    <div className="mb-4 flex items-center justify-center gap-2 rounded-md bg-gray-200 p-2 text-gray-800">
-      <InformationCircleIcon className="h-4" />
-      <span>
-        You can find the old instance of the Forex AMM on{' '}
-        <a
-          className="text-primary transition hover:underline"
-          href="https://old-forex-amm--rococo-souffle-a625f5.netlify.app/pendulum/nabla/swap"
-        >
-          this
-        </a>{' '}
-        page.
-      </span>
+    <div className="mb-4 flex justify-center">
+      <div className="flex w-fit items-center gap-2 rounded-md bg-gray-200 p-2 text-gray-800">
+        <InformationCircleIcon className="h-4" />
+        <span>
+          You can find the old instance of the Forex AMM on{' '}
+          <a
+            className="text-primary transition hover:underline"
+            href="https://old-forex-amm--rococo-souffle-a625f5.netlify.app/pendulum/nabla/swap"
+          >
+            this
+          </a>{' '}
+          page.
+        </span>
+      </div>
     </div>
   );
 }

--- a/src/config/apps/nabla.ts
+++ b/src/config/apps/nabla.ts
@@ -23,7 +23,7 @@ export const nablaConfig: NablaConfig = {
   },
   pendulum: {
     indexerUrl: 'https://pendulum.squids.live/pendulum-squid/graphql',
-    router: '6fEJAs1ycfTNDZY7ZoAtkBhuhHnRVNscdALMBLdjDV12K4uE',
-    oracle: '6fxpVAp3W5mJsXqnBiQresTd8HZDkNMRFCafbXC9X2AAjFHY',
+    router: '6gAVVw13mQgzzKk4yEwScMmWiCNyMAunXFJUZonbgKrym81N',
+    oracle: '6fzZ96uMJwPyMz9W8SRL7JfhFKc8GzG95YREHkV8kBJagkyV',
   },
 };

--- a/src/pages/nabla/backstop-pools/index.tsx
+++ b/src/pages/nabla/backstop-pools/index.tsx
@@ -1,8 +1,10 @@
 import BackstopPools from '../../../components/nabla/Pools/Backstop';
+import { OldForexAmmNotice } from '../../../components/nabla/common/OldForexAmmNotice';
 
 const BackstopPoolsPage = (): JSX.Element | null => {
   return (
     <div id="backstop-pools" className="center mt-6">
+      <OldForexAmmNotice />
       <BackstopPools />
     </div>
   );

--- a/src/pages/nabla/swap-pools/index.tsx
+++ b/src/pages/nabla/swap-pools/index.tsx
@@ -1,8 +1,10 @@
 import SwapPools from '../../../components/nabla/Pools/Swap';
+import { OldForexAmmNotice } from '../../../components/nabla/common/OldForexAmmNotice';
 
 const SwapPoolsPage = (): JSX.Element | null => {
   return (
-    <div id="swap-pools" className="mt-6">
+    <div id="swap-pools" className="center mt-6">
+      <OldForexAmmNotice />
       <SwapPools />
     </div>
   );

--- a/src/pages/nabla/swap-pools/index.tsx
+++ b/src/pages/nabla/swap-pools/index.tsx
@@ -3,7 +3,7 @@ import { OldForexAmmNotice } from '../../../components/nabla/common/OldForexAmmN
 
 const SwapPoolsPage = (): JSX.Element | null => {
   return (
-    <div id="swap-pools" className="center mt-6">
+    <div id="swap-pools" className="mt-6">
       <OldForexAmmNotice />
       <SwapPools />
     </div>

--- a/src/pages/nabla/swap/index.tsx
+++ b/src/pages/nabla/swap/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import Swap from '../../../components/nabla/Swap';
+import { OldForexAmmNotice } from '../../../components/nabla/common/OldForexAmmNotice';
 
 const SwapPage = (): JSX.Element | null => {
   const [params] = useSearchParams();
@@ -16,6 +17,7 @@ const SwapPage = (): JSX.Element | null => {
 
   return (
     <div id="swap" className="center mt-6">
+      <OldForexAmmNotice />
       <Swap from={params.get('from') || undefined} to={params.get('to') || undefined} onChange={onChange} />
     </div>
   );


### PR DESCRIPTION
- Create a component for the link to the old instance
- Show it on top of each swap page

I set up a separate deployment for the `old-forex-amm` branch in Netlify. The old instance is now available at https://old-forex-amm--rococo-souffle-a625f5.netlify.app.