### PR TITLE
[READY] remove unnecessary .Provider as React19 doesnt require it

### DIFF
--- a/src/GlobalStateProvider/index.tsx
+++ b/src/GlobalStateProvider/index.tsx
@@ -102,7 +102,7 @@ const GlobalStateProvider = ({ children }: { children: JSX.Element }) => {
     [dAppName, getThemeName, removeWalletAccount, setWalletAccount, tenantName, walletAccount],
   );
 
-  return <GlobalStateContext.Provider value={providerValue}>{children}</GlobalStateContext.Provider>;
+  return <GlobalStateContext value={providerValue}>{children}</GlobalStateContext>;
 };
 
 const useGlobalState = () => {

--- a/src/NodeInfoProvider.tsx
+++ b/src/NodeInfoProvider.tsx
@@ -118,7 +118,7 @@ const NodeInfoProvider = ({ children, tenantRPC }: { children: React.ReactNode; 
     }
   }, [currentTenantRPC, tenantRPC, pendingInitiationPromise, setPendingInitiationPromise]);
 
-  return <NodeInfoContext.Provider value={{ state, setState }}>{children}</NodeInfoContext.Provider>;
+  return <NodeInfoContext value={{ state, setState }}>{children}</NodeInfoContext>;
 };
 
 const useNodeInfoState = () => useContext(NodeInfoContext);

--- a/src/pages/spacewalk/bridge/index.tsx
+++ b/src/pages/spacewalk/bridge/index.tsx
@@ -73,7 +73,7 @@ function Bridge() {
   const bridgeDirection = tabValue === BridgeTabs.Issue ? BridgeDirection.Issue : BridgeDirection.Redeem;
 
   return chain ? (
-    <BridgeContext.Provider
+    <BridgeContext
       value={{
         selectedAsset,
         setSelectedAsset,
@@ -86,18 +86,18 @@ function Bridge() {
         setExtendedVaults,
       }}
     >
-      <div className="flex items-center justify-center mt-4">
+      <div className="mt-4 flex items-center justify-center">
         <SettingsDialog
           visible={settingsVisible}
           onClose={() => setSettingsVisible(false)}
           bridgeDirection={bridgeDirection}
         />
         <Card className="bridge-card min-h-500 w-full max-w-[520px] rounded-lg bg-base-200">
-          <div className="flex justify-between px-5 mt-5">
+          <div className="mt-5 flex justify-between px-5">
             <SpacewalkTabs activeTab={tabValue} setActiveTab={setTabValue} />
             <Button
               color="ghost"
-              className="min-h-0 p-1 m-auto settings h-fit"
+              className="settings m-auto h-fit min-h-0 p-1"
               onClick={() => setSettingsVisible(true)}
             >
               <SettingsIcon />
@@ -106,7 +106,7 @@ function Bridge() {
           {Content}
         </Card>
       </div>
-    </BridgeContext.Provider>
+    </BridgeContext>
   ) : (
     <></>
   );

--- a/src/services/modal/index.tsx
+++ b/src/services/modal/index.tsx
@@ -36,9 +36,9 @@ const ModalProvider = ({ children }: ModalProviderProps): JSX.Element | null => 
   }, []);
 
   return (
-    <ModalStateContext.Provider value={state}>
-      <ModalToggleContext.Provider value={toggleModal}>{children}</ModalToggleContext.Provider>
-    </ModalStateContext.Provider>
+    <ModalStateContext value={state}>
+      <ModalToggleContext value={toggleModal}>{children}</ModalToggleContext>
+    </ModalStateContext>
   );
 };
 

--- a/src/shared/Provider.tsx
+++ b/src/shared/Provider.tsx
@@ -18,7 +18,7 @@ export const SharedStateProvider = ({ children, api, signer, address }: { childr
     }),
     [api, signer, address],
   );
-  return <SharedStateContext.Provider value={providerValue}>{children}</SharedStateContext.Provider>;
+  return <SharedStateContext value={providerValue}>{children}</SharedStateContext>;
 };
 
 export const useSharedState = () => {


### PR DESCRIPTION
Simple lexical sugar change
In React 19, you can render <Context> as a provider instead of <Context.Provider>
https://react.dev/blog/2024/12/05/react-19#context-as-a-provider