### PR TITLE
Add PEN → Base migration page

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -21,6 +21,7 @@ export enum PATHS {
   NABLA_BACKSTOP_POOLS = 'backstop-pools',
   STAKING = 'staking',
   FUND_WALLET = 'fund-wallet',
+  MIGRATION = 'migration',
 }
 
 export const PAGES_PATHS = {
@@ -34,6 +35,7 @@ export const PAGES_PATHS = {
   NABLA_BACKSTOP_POOLS: `${PATHS.NABLA}/${PATHS.NABLA_BACKSTOP_POOLS}`,
   STAKING: PATHS.STAKING,
   FUND_WALLET: PATHS.FUND_WALLET,
+  MIGRATION: PATHS.MIGRATION,
 };
 
 /**
@@ -55,6 +57,7 @@ const SwapPage = loadPage(PAGES_PATHS.NABLA_SWAP);
 const SwapPoolsPage = loadPage(PAGES_PATHS.NABLA_SWAP_POOLS);
 const BackstopPoolsPage = loadPage(PAGES_PATHS.NABLA_BACKSTOP_POOLS);
 const FundWalletPage = loadPage(PAGES_PATHS.FUND_WALLET);
+const MigrationPage = loadPage(PAGES_PATHS.MIGRATION);
 
 export function App() {
   return (
@@ -78,6 +81,7 @@ export function App() {
           </Route>
           <Route path={PATHS.STAKING} element={Staking} />
           <Route path={PATHS.FUND_WALLET} element={FundWalletPage} />
+          <Route path={PATHS.MIGRATION} element={MigrationPage} />
           <Route path="*" element={<NotFound />} />
         </Route>
         <Route path="staking" element={Staking} />

--- a/src/components/Layout/links.tsx
+++ b/src/components/Layout/links.tsx
@@ -132,6 +132,16 @@ export function createLinks(tenantName: TenantName): LinkItem[] {
     prefix: <StakingIcon />,
   };
 
+  const migrationLinkItem: LinkItem = {
+    link: `./${PAGES_PATHS.MIGRATION}`,
+    title: 'Migrate to Base',
+    hidden: tenantName !== TenantName.Pendulum,
+    props: {
+      className: ({ isActive } = {}) => (isActive ? 'active' : ''),
+    },
+    prefix: <SwapIcon className="p-1" />,
+  };
+
   const governanceLinkItem: LinkItem = {
     link: `https://${tenantName}.polkassembly.io/`,
     title: 'Governance',
@@ -158,6 +168,7 @@ export function createLinks(tenantName: TenantName): LinkItem[] {
     spacewalkLinkItem,
     nablaLinkItem,
     stakingLinkItem,
+    migrationLinkItem,
     governanceLinkItem,
     fundWalletItem,
   ];

--- a/src/constants/migration.ts
+++ b/src/constants/migration.ts
@@ -1,0 +1,27 @@
+import { TenantName } from '../models/Tenant';
+
+export interface MigrationTargetConfig {
+  /** Base JSON-RPC endpoint used for read-only status polling. */
+  baseRpcUrl: string;
+  /** MigrationVault contract address on Base. Empty until deployment. */
+  vaultAddress: string;
+  baseExplorerUrl: string;
+}
+
+/**
+ * Base-side deployment targets for the PEN migration. The migration page only
+ * shows Base release tracking when the vault address for the current tenant
+ * is configured (set at deployment, PRD rollout phase 3/4).
+ */
+export const migrationTargets: Partial<Record<TenantName, MigrationTargetConfig>> = {
+  [TenantName.Pendulum]: {
+    baseRpcUrl: (import.meta.env.VITE_BASE_RPC_URL as string | undefined) ?? 'https://mainnet.base.org',
+    vaultAddress: (import.meta.env.VITE_MIGRATION_VAULT_ADDRESS as string | undefined) ?? '',
+    baseExplorerUrl: 'https://basescan.org',
+  },
+};
+
+export function getMigrationTarget(tenantName: TenantName): MigrationTargetConfig | undefined {
+  const target = migrationTargets[tenantName];
+  return target?.vaultAddress ? target : undefined;
+}

--- a/src/helpers/ethereum.ts
+++ b/src/helpers/ethereum.ts
@@ -19,12 +19,14 @@ export function toChecksumAddress(address: string): string {
 }
 
 /**
- * Valid destination address for the migration. Mixed-case addresses must have
- * a correct EIP-55 checksum; single-case addresses carry no checksum
- * information and are accepted as-is.
+ * Valid destination address for the migration. The zero address is rejected
+ * (the vault refuses it, so the burn could never be released); mixed-case
+ * addresses must have a correct EIP-55 checksum; single-case addresses carry
+ * no checksum information and are accepted as-is.
  */
 export function isValidEip55Address(address: string): boolean {
   if (!isHexAddressFormat(address)) return false;
+  if (/^0x0{40}$/.test(address)) return false;
   const body = address.slice(2);
   const isMixedCase = /[A-F]/.test(body) && /[a-f]/.test(body);
   return isMixedCase ? toChecksumAddress(address) === address : true;

--- a/src/helpers/ethereum.ts
+++ b/src/helpers/ethereum.ts
@@ -1,0 +1,91 @@
+import { keccakAsHex } from '@polkadot/util-crypto';
+
+/** Basic shape check: 0x + 40 hex chars. */
+export function isHexAddressFormat(address: string): boolean {
+  return /^0x[0-9a-fA-F]{40}$/.test(address);
+}
+
+/** EIP-55 checksummed form of an address. */
+export function toChecksumAddress(address: string): string {
+  const lower = address.toLowerCase().replace(/^0x/, '');
+  // keccak of the ASCII lowercase hex string (EIP-55); the missing 0x prefix
+  // makes keccakAsHex treat the input as a plain string, which is intended.
+  const hash = keccakAsHex(lower, 256).slice(2);
+  let checksummed = '0x';
+  for (let i = 0; i < lower.length; i++) {
+    checksummed += parseInt(hash[i], 16) >= 8 ? lower[i].toUpperCase() : lower[i];
+  }
+  return checksummed;
+}
+
+/**
+ * Valid destination address for the migration. Mixed-case addresses must have
+ * a correct EIP-55 checksum; single-case addresses carry no checksum
+ * information and are accepted as-is.
+ */
+export function isValidEip55Address(address: string): boolean {
+  if (!isHexAddressFormat(address)) return false;
+  const body = address.slice(2);
+  const isMixedCase = /[A-F]/.test(body) && /[a-f]/.test(body);
+  return isMixedCase ? toChecksumAddress(address) === address : true;
+}
+
+async function rpc(baseRpcUrl: string, method: string, params: unknown[]): Promise<string> {
+  const response = await fetch(baseRpcUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  });
+  const json = (await response.json()) as { result?: string; error?: { message: string } };
+  if (json.error || json.result === undefined) {
+    throw new Error(`Base RPC ${method} failed: ${json.error?.message ?? 'no result'}`);
+  }
+  return json.result;
+}
+
+function to32ByteWord(value: bigint): string {
+  return value.toString(16).padStart(64, '0');
+}
+
+function addressWord(address: string): string {
+  return address.toLowerCase().replace(/^0x/, '').padStart(64, '0');
+}
+
+// Function selectors of the MigrationVault (see contracts/src/MigrationVault.sol
+// in the pendulum repo); computed with `cast sig`.
+const SELECTOR_NONCE_CONSUMED = '0xe406947e'; // nonceConsumed(uint64)
+const SELECTOR_ACTIVE_APPROVALS = '0xab3894a7'; // activeApprovals(bytes32)
+const SELECTOR_THRESHOLD = '0x42cde4e8'; // threshold()
+
+/** keccak256(abi.encode(uint64 nonce, address recipient, uint256 palletAmount)) */
+export function migrationPayloadHash(nonce: bigint, recipient: string, palletAmount: bigint): string {
+  const encoded = `0x${to32ByteWord(nonce)}${addressWord(recipient)}${to32ByteWord(palletAmount)}`;
+  return keccakAsHex(encoded, 256);
+}
+
+export async function isNonceConsumed(baseRpcUrl: string, vault: string, nonce: bigint): Promise<boolean> {
+  const result = await rpc(baseRpcUrl, 'eth_call', [
+    { to: vault, data: `${SELECTOR_NONCE_CONSUMED}${to32ByteWord(nonce)}` },
+    'latest',
+  ]);
+  return BigInt(result) === 1n;
+}
+
+export async function getActiveApprovals(baseRpcUrl: string, vault: string, payloadHash: string): Promise<number> {
+  const result = await rpc(baseRpcUrl, 'eth_call', [
+    { to: vault, data: `${SELECTOR_ACTIVE_APPROVALS}${payloadHash.replace(/^0x/, '')}` },
+    'latest',
+  ]);
+  return Number(BigInt(result));
+}
+
+export async function getApprovalThreshold(baseRpcUrl: string, vault: string): Promise<number> {
+  const result = await rpc(baseRpcUrl, 'eth_call', [{ to: vault, data: SELECTOR_THRESHOLD }, 'latest']);
+  return Number(BigInt(result));
+}
+
+/** True when the address has deployed code on Base (a smart contract). */
+export async function isContractOnBase(baseRpcUrl: string, address: string): Promise<boolean> {
+  const code = await rpc(baseRpcUrl, 'eth_getCode', [address, 'latest']);
+  return code !== '0x' && code !== '0x0';
+}

--- a/src/hooks/migration/useBaseReleaseStatus.ts
+++ b/src/hooks/migration/useBaseReleaseStatus.ts
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query';
+import { MigrationTargetConfig } from '../../constants/migration';
+import {
+  getActiveApprovals,
+  getApprovalThreshold,
+  isNonceConsumed,
+  migrationPayloadHash,
+} from '../../helpers/ethereum';
+import { PendingMigration } from './useMigrationPallet';
+
+export interface BaseReleaseStatus {
+  released: boolean;
+  approvals: number;
+  threshold: number;
+}
+
+/**
+ * Polls the MigrationVault on Base for the release status of a finalized
+ * migration: how many active attestor approvals the exact
+ * (nonce, recipient, amount) tuple has, and whether the nonce was consumed
+ * (= tokens released). Polling stops once released.
+ */
+export function useBaseReleaseStatus(migration: PendingMigration | undefined, target: MigrationTargetConfig | undefined) {
+  return useQuery<BaseReleaseStatus>(
+    ['migration', 'baseStatus', migration?.nonce.toString()],
+    async () => {
+      if (!migration || !target) throw new Error('not enabled');
+      const payload = migrationPayloadHash(migration.nonce, migration.recipient, migration.palletAmount);
+      const [released, approvals, threshold] = await Promise.all([
+        isNonceConsumed(target.baseRpcUrl, target.vaultAddress, migration.nonce),
+        getActiveApprovals(target.baseRpcUrl, target.vaultAddress, payload),
+        getApprovalThreshold(target.baseRpcUrl, target.vaultAddress),
+      ]);
+      return { released, approvals, threshold };
+    },
+    {
+      enabled: Boolean(migration && target),
+      refetchInterval: (data) => (data?.released ? false : 10_000),
+      retry: 3,
+    },
+  );
+}

--- a/src/hooks/migration/useMigrationPallet.tsx
+++ b/src/hooks/migration/useMigrationPallet.tsx
@@ -1,0 +1,113 @@
+import { ApiPromise } from '@polkadot/api';
+import { WalletAccount } from '@talismn/connect-wallets';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+import { useNodeInfoState } from '../../NodeInfoProvider';
+import { getErrors } from '../../helpers/substrate';
+import { nativeToDecimal } from '../../shared/parseNumbers/metric';
+
+export interface PendingMigration {
+  nonce: bigint;
+  recipient: string;
+  /** Burned amount in native (pallet) units, i.e. 12 decimals. */
+  palletAmount: bigint;
+}
+
+interface MigrationPalletConstants {
+  /** Minimum migratable amount, in token units (decimal). */
+  minimumMigrationAmount: number;
+  /** Existential deposit, in token units (decimal). */
+  existentialDeposit: number;
+}
+
+function extractMigrationInitiated(api: ApiPromise, events: { event: unknown }[]): PendingMigration | undefined {
+  for (const record of events) {
+    const event = record.event as { section: string; method: string; data: unknown[] };
+    if (event.section === 'tokenMigration' && event.method === 'MigrationInitiated') {
+      const [nonce, , baseAddress, amount] = event.data as [
+        { toString(): string },
+        unknown,
+        { toHex(): string },
+        { toString(): string },
+      ];
+      return {
+        nonce: BigInt(nonce.toString()),
+        recipient: baseAddress.toHex(),
+        palletAmount: BigInt(amount.toString().replaceAll(',', '')),
+      };
+    }
+  }
+  return undefined;
+}
+
+export function useMigrationPallet() {
+  const { api, tokenDecimals } = useNodeInfoState().state;
+
+  const palletAvailable = Boolean(api && api.tx.tokenMigration?.migrate);
+
+  const constants = useMemo<MigrationPalletConstants | undefined>(() => {
+    if (!api || !palletAvailable) return undefined;
+    return {
+      minimumMigrationAmount: nativeToDecimal(
+        api.consts.tokenMigration.minimumMigrationAmount.toString(),
+        tokenDecimals,
+      ).toNumber(),
+      existentialDeposit: nativeToDecimal(api.consts.balances.existentialDeposit.toString(), tokenDecimals).toNumber(),
+    };
+  }, [api, palletAvailable, tokenDecimals]);
+
+  const pausedQuery = useQuery<boolean>(
+    ['tokenMigration', 'paused'],
+    async () => {
+      if (!api) return false;
+      const paused = await api.query.tokenMigration.paused();
+      return paused.toPrimitive() === true;
+    },
+    { enabled: Boolean(api && palletAvailable), refetchInterval: 30_000 },
+  );
+
+  /**
+   * Signs and submits `tokenMigration.migrate(amount, baseAddress)`, resolving
+   * once the transaction is FINALIZED with the emitted migration identifiers
+   * needed to track the release on Base.
+   */
+  const submitMigration = useCallback(
+    (amountNative: string, baseAddress: string, walletAccount: WalletAccount): Promise<PendingMigration> => {
+      if (!api) return Promise.reject(new Error('API not ready'));
+      const extrinsic = api.tx.tokenMigration.migrate(amountNative, baseAddress);
+
+      return new Promise<PendingMigration>((resolve, reject) =>
+        extrinsic
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .signAndSend(walletAccount.address, { signer: walletAccount.signer as any }, (result) => {
+            const { status, events } = result;
+            const errors = getErrors(events, api);
+
+            if (status.isInBlock && errors.length > 0) {
+              reject(new Error(`Transaction failed: ${errors.join('\n')}`));
+            } else if (status.isFinalized) {
+              if (errors.length > 0) {
+                reject(new Error(`Transaction failed: ${errors.join('\n')}`));
+                return;
+              }
+              const migration = extractMigrationInitiated(api, events);
+              if (migration) {
+                resolve(migration);
+              } else {
+                reject(new Error('MigrationInitiated event not found in finalized transaction'));
+              }
+            }
+          })
+          .catch((error: Error) => reject(error)),
+      );
+    },
+    [api],
+  );
+
+  return {
+    palletAvailable,
+    constants,
+    paused: pausedQuery.data === true,
+    submitMigration,
+  };
+}

--- a/src/pages/migration/ValidationSchema.ts
+++ b/src/pages/migration/ValidationSchema.ts
@@ -14,6 +14,11 @@ interface SchemaParams {
   minimumMigrationAmount: number;
   existentialDeposit: number;
   tokenSymbol: string;
+  /** MigrationVault address on Base ('' until configured). Rejected as a
+   *  destination: the vault refuses a release to itself, so burning towards it
+   *  would strand the funds (and, on-chain, this is the one address the pallet
+   *  cannot reject because it has no knowledge of Base state). */
+  vaultAddress: string;
 }
 
 export function getMigrationValidationSchema({
@@ -22,6 +27,7 @@ export function getMigrationValidationSchema({
   minimumMigrationAmount,
   existentialDeposit,
   tokenSymbol,
+  vaultAddress,
 }: SchemaParams) {
   return Yup.object<MigrationFormValues>().shape({
     amount: Yup.number()
@@ -46,6 +52,11 @@ export function getMigrationValidationSchema({
         'eip55',
         'Not a valid Base (EVM) address — check the 0x-prefixed address and its checksum',
         (value) => Boolean(value && isValidEip55Address(value)),
+      )
+      .test(
+        'not-vault',
+        'That is the migration vault address — tokens sent there can never be released. Enter your own Base wallet address.',
+        (value) => !vaultAddress || !value || value.toLowerCase() !== vaultAddress.toLowerCase(),
       ),
     confirmIrreversible: Yup.boolean()
       .required()

--- a/src/pages/migration/ValidationSchema.ts
+++ b/src/pages/migration/ValidationSchema.ts
@@ -1,0 +1,54 @@
+import * as Yup from 'yup';
+import { transformNumber } from '../../helpers/yup';
+import { isValidEip55Address } from '../../helpers/ethereum';
+
+export interface MigrationFormValues {
+  amount: number;
+  baseAddress: string;
+  confirmIrreversible: boolean;
+}
+
+interface SchemaParams {
+  transferable: number;
+  total: number;
+  minimumMigrationAmount: number;
+  existentialDeposit: number;
+  tokenSymbol: string;
+}
+
+export function getMigrationValidationSchema({
+  transferable,
+  total,
+  minimumMigrationAmount,
+  existentialDeposit,
+  tokenSymbol,
+}: SchemaParams) {
+  return Yup.object<MigrationFormValues>().shape({
+    amount: Yup.number()
+      .transform(transformNumber)
+      .positive('The amount must be positive')
+      .required('The amount is required')
+      .min(minimumMigrationAmount, `The minimum migration amount is ${minimumMigrationAmount} ${tokenSymbol}`)
+      .max(transferable, `The amount exceeds your transferable balance of ${transferable.toFixed(4)} ${tokenSymbol}`)
+      .test(
+        'ed-rule',
+        `Migrate your entire balance or leave at least ${existentialDeposit} ${tokenSymbol} behind — a smaller remainder would be lost as dust`,
+        (value) => {
+          if (value === undefined) return false;
+          const remainder = total - value;
+          // Tolerance for float representation of 12-decimal amounts.
+          return remainder <= 1e-9 || remainder >= existentialDeposit;
+        },
+      ),
+    baseAddress: Yup.string()
+      .required('The Base address is required')
+      .test(
+        'eip55',
+        'Not a valid Base (EVM) address — check the 0x-prefixed address and its checksum',
+        (value) => Boolean(value && isValidEip55Address(value)),
+      ),
+    confirmIrreversible: Yup.boolean()
+      .required()
+      .oneOf([true], 'You must confirm that you understand the migration is irreversible'),
+  });
+}

--- a/src/pages/migration/__tests__/ValidationSchema.test.ts
+++ b/src/pages/migration/__tests__/ValidationSchema.test.ts
@@ -1,0 +1,49 @@
+import { getMigrationValidationSchema } from '../ValidationSchema';
+
+const VAULT = '0x1111111111111111111111111111111111111111';
+
+function schema(vaultAddress = VAULT) {
+  return getMigrationValidationSchema({
+    transferable: 1000,
+    total: 1000,
+    minimumMigrationAmount: 100,
+    existentialDeposit: 1,
+    tokenSymbol: 'PEN',
+    vaultAddress,
+  });
+}
+
+async function baseAddressValid(value: string, vaultAddress = VAULT): Promise<boolean> {
+  try {
+    await schema(vaultAddress).validateAt('baseAddress', { baseAddress: value });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('migration baseAddress validation', () => {
+  it('accepts a normal Base wallet address', async () => {
+    expect(await baseAddressValid('0x00000000000000000000000000000000deadbeef')).toBe(true);
+  });
+
+  it('rejects the migration vault address as a destination', async () => {
+    // The round-6 defence-in-depth: burning towards the vault can never be
+    // released, and it is the one address the pallet cannot reject on-chain.
+    expect(await baseAddressValid(VAULT)).toBe(false);
+  });
+
+  it('rejects the vault address case-insensitively', async () => {
+    const value = '0xabcdef0000000000000000000000000000000001'; // lower-case, passes eip55
+    const vaultUpperCase = '0xABCDEF0000000000000000000000000000000001'; // same address, configured upper-case
+    expect(await baseAddressValid(value, vaultUpperCase)).toBe(false);
+  });
+
+  it('still rejects the zero address', async () => {
+    expect(await baseAddressValid('0x0000000000000000000000000000000000000000')).toBe(false);
+  });
+
+  it('does not apply the vault check when no vault address is configured', async () => {
+    expect(await baseAddressValid('0x00000000000000000000000000000000deadbeef', '')).toBe(true);
+  });
+});

--- a/src/pages/migration/index.tsx
+++ b/src/pages/migration/index.tsx
@@ -1,0 +1,281 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useMemo, useState } from 'react';
+import { Button } from 'react-daisyui';
+import { useForm } from 'react-hook-form';
+import { useQuery } from '@tanstack/react-query';
+
+import { useGlobalState } from '../../GlobalStateProvider';
+import { useNodeInfoState } from '../../NodeInfoProvider';
+import Amount from '../../components/Form/Amount';
+import { getMigrationTarget } from '../../constants/migration';
+import { isContractOnBase, isValidEip55Address, toChecksumAddress } from '../../helpers/ethereum';
+import { useBaseReleaseStatus } from '../../hooks/migration/useBaseReleaseStatus';
+import { PendingMigration, useMigrationPallet } from '../../hooks/migration/useMigrationPallet';
+import { TenantName } from '../../models/Tenant';
+import { decimalToNative, nativeToDecimal } from '../../shared/parseNumbers/metric';
+import { ToastMessage, showToast } from '../../shared/showToast';
+import { useAccountBalance } from '../../shared/useAccountBalance';
+import { MigrationFormValues, getMigrationValidationSchema } from './ValidationSchema';
+
+function ReleaseStatusCard({
+  migration,
+  tenantName,
+  tokenSymbol,
+  tokenDecimals,
+  onDone,
+}: {
+  migration: PendingMigration;
+  tenantName: TenantName;
+  tokenSymbol: string;
+  tokenDecimals: number;
+  onDone: () => void;
+}) {
+  const target = getMigrationTarget(tenantName);
+  const { data: status } = useBaseReleaseStatus(migration, target);
+  const checksummedRecipient = toChecksumAddress(migration.recipient);
+  const amount = nativeToDecimal(migration.palletAmount.toString(), tokenDecimals).toString();
+
+  return (
+    <div className="card mt-4 bg-base-200 p-4">
+      <h2 className="text-lg font-bold">Migration #{migration.nonce.toString()} submitted 🎉</h2>
+      <p className="mt-2 text-sm">
+        {amount} {tokenSymbol} were burned on {tenantName} and will be released to{' '}
+        <span className="break-all font-mono">{checksummedRecipient}</span> on Base by the attestor set.
+      </p>
+      <div className="mt-3 text-sm">
+        {!target ? (
+          <span>Base status tracking is not configured; check your Base wallet in a few minutes.</span>
+        ) : status?.released ? (
+          <span className="font-semibold text-success">
+            ✓ Released on Base —{' '}
+            <a
+              className="link"
+              href={`${target.baseExplorerUrl}/address/${checksummedRecipient}`}
+              target="_blank"
+              rel="nofollow noreferrer"
+            >
+              view on BaseScan
+            </a>
+          </span>
+        ) : (
+          <span>
+            Waiting for attestor approvals ({status ? `${Math.min(status.approvals, status.threshold)}/${status.threshold}` : '…'})
+            — this normally completes within a few minutes of finality.
+          </span>
+        )}
+      </div>
+      <div className="mt-3">
+        <Button size="sm" color="secondary" type="button" onClick={onDone}>
+          Start another migration
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function Migration() {
+  const { walletAccount, tenantName } = useGlobalState();
+  const { api, tokenSymbol = 'PEN', tokenDecimals } = useNodeInfoState().state;
+  const { palletAvailable, constants, paused, submitMigration } = useMigrationPallet();
+  const { balances } = useAccountBalance(walletAccount?.address);
+
+  const [submissionPending, setSubmissionPending] = useState(false);
+  const [pendingMigration, setPendingMigration] = useState<PendingMigration | undefined>(undefined);
+  const [contractConfirmed, setContractConfirmed] = useState(false);
+
+  const target = getMigrationTarget(tenantName);
+  const lockedBalance = Math.max(0, balances.total - balances.transferable);
+
+  const schema = useMemo(
+    () =>
+      getMigrationValidationSchema({
+        transferable: balances.transferable,
+        total: balances.total,
+        minimumMigrationAmount: constants?.minimumMigrationAmount ?? 1,
+        existentialDeposit: constants?.existentialDeposit ?? 0,
+        tokenSymbol,
+      }),
+    [balances.transferable, balances.total, constants, tokenSymbol],
+  );
+
+  const { register, control, handleSubmit, setValue, watch, formState, reset } = useForm<MigrationFormValues>({
+    resolver: yupResolver(schema),
+    defaultValues: { confirmIrreversible: false },
+  });
+
+  const baseAddress = watch('baseAddress') ?? '';
+  const addressIsValid = isValidEip55Address(baseAddress);
+  const checksummedAddress = addressIsValid ? toChecksumAddress(baseAddress) : undefined;
+
+  const { data: destinationIsContract } = useQuery(
+    ['migration', 'isContract', checksummedAddress],
+    () => isContractOnBase(target!.baseRpcUrl, checksummedAddress!),
+    { enabled: Boolean(target && checksummedAddress), staleTime: 60_000 },
+  );
+
+  if (tenantName !== TenantName.Pendulum) {
+    return (
+      <div className="card mx-auto mt-8 w-full max-w-xl bg-base-200 p-6">
+        <h1 className="text-2xl font-bold">Migrate to Base</h1>
+        <p className="mt-2">The PEN token migration is only available on the Pendulum network.</p>
+      </div>
+    );
+  }
+
+  if (!api || !palletAvailable) {
+    return (
+      <div className="card mx-auto mt-8 w-full max-w-xl bg-base-200 p-6">
+        <h1 className="text-2xl font-bold">Migrate to Base</h1>
+        <p className="mt-2">
+          {api ? 'The migration is not enabled on this chain yet. Please check back later.' : 'Connecting to the node…'}
+        </p>
+      </div>
+    );
+  }
+
+  const onSubmit = async (values: MigrationFormValues) => {
+    if (!walletAccount) {
+      showToast(ToastMessage.NO_WALLET_SELECTED);
+      return;
+    }
+    if (destinationIsContract && !contractConfirmed) {
+      showToast(ToastMessage.WARNING, 'Please confirm the smart-contract destination first.');
+      return;
+    }
+    setSubmissionPending(true);
+    try {
+      const amountNative = decimalToNative(values.amount, tokenDecimals).toString();
+      const migration = await submitMigration(amountNative, toChecksumAddress(values.baseAddress), walletAccount);
+      setPendingMigration(migration);
+      reset();
+      setContractConfirmed(false);
+    } catch (error) {
+      showToast(ToastMessage.ERROR, error instanceof Error ? error.message : 'Migration failed');
+    } finally {
+      setSubmissionPending(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto mt-4 w-full max-w-xl">
+      <div className="card bg-base-200 p-6">
+        <h1 className="text-2xl font-bold">Migrate {tokenSymbol} to Base</h1>
+        <p className="mt-2 text-sm text-neutral-500">
+          Lock in your migration: the amount is burned on Pendulum and released 1:1 to your address on Base by a 3-of-5
+          attestor set after finality.{' '}
+          <strong>This is irreversible — tokens sent to a wrong address cannot be recovered.</strong>
+        </p>
+
+        {paused && (
+          <div className="alert alert-warning mt-4 text-sm">
+            Migrations are currently paused. Submissions are disabled until they resume.
+          </div>
+        )}
+
+        {!walletAccount ? (
+          <div className="alert mt-4 text-sm">Connect your wallet to start the migration.</div>
+        ) : (
+          <form className="mt-4" onSubmit={handleSubmit(onSubmit)}>
+            <Amount
+              control={control}
+              name="amount"
+              setValue={(n) => setValue('amount', n, { shouldValidate: true })}
+              max={balances.transferable}
+              error={formState.errors.amount?.message}
+              assetSuffix={tokenSymbol}
+              hideHalfButton
+            />
+            {lockedBalance > 0.0001 && (
+              <p className="mt-1 text-xs text-neutral-500">
+                {lockedBalance.toFixed(4)} {tokenSymbol} of your balance is locked (staking, vesting or governance).
+                Unlock it first to migrate it — note the unstaking delay applies.
+              </p>
+            )}
+
+            <label className="label mt-3">
+              <span className="label-text">Your Base (EVM) address</span>
+            </label>
+            <input
+              className={`input input-bordered w-full font-mono text-sm ${
+                baseAddress && !addressIsValid ? 'input-error' : ''
+              }`}
+              placeholder="0x…"
+              autoComplete="off"
+              spellCheck={false}
+              {...register('baseAddress')}
+            />
+            {formState.errors.baseAddress?.message && (
+              <label className="label">
+                <span className="label-text text-red-400">{formState.errors.baseAddress.message}</span>
+              </label>
+            )}
+            {checksummedAddress && checksummedAddress !== baseAddress && (
+              <p className="mt-1 break-all text-xs text-neutral-500">
+                Will be sent to <span className="font-mono">{checksummedAddress}</span>
+              </p>
+            )}
+
+            {destinationIsContract && (
+              <div className="alert alert-warning mt-3 text-sm">
+                <div>
+                  <p>
+                    This address is a <strong>smart contract</strong> on Base. Only continue if you are certain it can
+                    hold and move ERC-20 tokens (e.g. a Safe) — otherwise the tokens will be stuck forever.
+                  </p>
+                  <label className="mt-2 flex cursor-pointer items-center gap-2">
+                    <input
+                      type="checkbox"
+                      className="checkbox checkbox-sm"
+                      checked={contractConfirmed}
+                      onChange={(e) => setContractConfirmed(e.target.checked)}
+                    />
+                    <span>I verified this contract can receive ERC-20 tokens</span>
+                  </label>
+                </div>
+              </div>
+            )}
+
+            <label className="mt-4 flex cursor-pointer items-center gap-2">
+              <input type="checkbox" className="checkbox checkbox-sm" {...register('confirmIrreversible')} />
+              <span className="text-sm">
+                I understand this migration is <strong>irreversible</strong> and my {tokenSymbol} on Pendulum will be
+                burned.
+              </span>
+            </label>
+            {formState.errors.confirmIrreversible?.message && (
+              <label className="label">
+                <span className="label-text text-red-400">{formState.errors.confirmIrreversible.message}</span>
+              </label>
+            )}
+
+            <p className="mt-3 text-xs text-neutral-500">
+              Tip for large amounts: do a small test migration first and confirm it arrives on Base.
+            </p>
+
+            <Button
+              className="mt-4 w-full"
+              color="primary"
+              type="submit"
+              disabled={paused || submissionPending}
+              loading={submissionPending}
+            >
+              {submissionPending ? 'Waiting for finalization…' : `Migrate ${tokenSymbol} to Base`}
+            </Button>
+          </form>
+        )}
+      </div>
+
+      {pendingMigration && (
+        <ReleaseStatusCard
+          migration={pendingMigration}
+          tenantName={tenantName}
+          tokenSymbol={tokenSymbol}
+          tokenDecimals={tokenDecimals ?? 12}
+          onDone={() => setPendingMigration(undefined)}
+        />
+      )}
+    </div>
+  );
+}
+
+export default Migration;

--- a/src/pages/migration/index.tsx
+++ b/src/pages/migration/index.tsx
@@ -94,8 +94,9 @@ function Migration() {
         minimumMigrationAmount: constants?.minimumMigrationAmount ?? 1,
         existentialDeposit: constants?.existentialDeposit ?? 0,
         tokenSymbol,
+        vaultAddress: target?.vaultAddress ?? '',
       }),
-    [balances.transferable, balances.total, constants, tokenSymbol],
+    [balances.transferable, balances.total, constants, tokenSymbol, target?.vaultAddress],
   );
 
   const { register, control, handleSubmit, setValue, watch, formState, reset } = useForm<MigrationFormValues>({


### PR DESCRIPTION
## Overview

Adds the user-facing **PEN → Base migration** page to the portal — the frontend companion to the migration stack in [`pendulum-chain/pendulum#558`](https://github.com/pendulum-chain/pendulum/pull/558).

Users connect their Substrate wallet, enter an amount and a Base (EVM) destination, and submit `tokenMigration.migrate(...)`; after finalization the page tracks the release on the Base MigrationVault (attestor approvals x/3 → released).

## What's in this PR (2 commits)

- **`src/pages/migration/`** — the migration page: amount validation (transferable balance, minimum, migrate-all-or-leave-ED), **EIP-55** address validation with checksummed preview, zero-address rejection, `eth_getCode` smart-contract-destination warning + extra confirmation, irreversibility confirmation, pallet-pause banner, locked-balance hint, and post-finalization release tracking.
- **`src/hooks/migration/`** — `useMigrationPallet` (extrinsic submission resolving at finality with the emitted nonce) and `useBaseReleaseStatus` (polls the vault over plain JSON-RPC).
- **`src/helpers/ethereum.ts`** — EIP-55 checksum, payload-hash mirroring the vault's `abi.encode`, minimal `eth_call`/`eth_getCode` client. **No EVM library added** — keccak via `@polkadot/util-crypto`.
- **`src/constants/migration.ts`** — vault address via `VITE_MIGRATION_VAULT_ADDRESS`; the page degrades gracefully when unset. Nav item is Pendulum-only.

## Base branch

Rebased onto **`main`** (the current React 19 mainline). The amount input uses the `Amount` component's current `control`/`name` (react-hook-form `Controller`) API. Verified with a full `yarn build` (`tsc && vite build`) against `main`.

## Verification

`yarn build` clean (tsc + vite); committed through the repo's lint-staged hook.

## Before deploy

Set `VITE_MIGRATION_VAULT_ADDRESS` (and optionally `VITE_BASE_RPC_URL`) once the vault is deployed on Base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)